### PR TITLE
feat: checking if the requested blueprint exists in the fullnode

### DIFF
--- a/packages/hathor-rpc-handler/src/errors/index.ts
+++ b/packages/hathor-rpc-handler/src/errors/index.ts
@@ -18,3 +18,7 @@ export class DifferentNetworkError extends Error {};
 export class NoUtxosAvailableError extends Error {};
 
 export class SignMessageError extends Error {};
+
+export class ParamsValidationError extends Error {};
+
+export class BluePrintNotFoundError extends ParamsValidationError {};


### PR DESCRIPTION
### Motivation

We should validate the blueprint id before yielding prompts to the clients

### Acceptance Criteria

- We should request the fullnode for the blueprint information and fail if unable to fetch it.

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
