### PR TITLE
docs(API): create reference documentation for API using Open RPC standard

### DIFF
--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -211,7 +211,7 @@
         },
         {
           "name": "maximumAmount",
-          "summary": "Returns only UTXOs smaller or equal than specified amount",
+          "summary": "Limit the maximum total amount to return summing all utxos",
           "schema": {
             "type": "number"
           }
@@ -378,7 +378,7 @@
     {
       "name": "htr_createToken",
       "summary": "Requests user to create token",
-      "description": "Provides user the deailts for a token creation. dApp provides wallet application with data that comprises a token creation. Wallet application assembles and signs transaction, and then pushes it to network or returns it to dApp.",
+      "description": "Provides user the details for a token creation. dApp provides wallet application with data that comprises a token creation. Wallet application assembles and signs transaction, and then pushes it to network or returns it to dApp.",
       "paramStructure": "by-name",
       "params": [
         {
@@ -580,13 +580,12 @@
       "Network": {
         "enum": [
           "testnet",
-          "mainnet"
+          "mainnet",
+          "privatenet"
         ]
       },
       "Token": {
-        "description": "32 bytes encoded in hexadecimal.",
-        "type": "string",
-        "pattern": "^[a-fA-F0-9]{64}$"
+        "$ref": "#/components/schemas/TransactionId"
       },
       "GetBalanceObject": {
         "type": "object",
@@ -615,9 +614,7 @@
         "type": "object",
         "properties": {
           "id": {
-            "description": "32 bytes encoded in hexadecimal.",
-            "type": "string",
-            "pattern": "^[a-fA-F0-9]{64}$"
+            "$ref": "#/components/schemas/Token"
           },
           "name": {
             "description": "UTF-8 characters.",
@@ -676,7 +673,7 @@
         }
       },
       "Address": {
-        "description": "20 bytes encoded in base58check.",
+        "description": "25 bytes encoded in base58check.",
         "type": "string",
         "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{34}$"
       },
@@ -710,12 +707,10 @@
             "$ref": "#/components/schemas/Address"
           },
           "amount": {
-            "type": "number"
+            "$ref": "#/components/schemas/OutputValueType"
           },
           "tx_id": {
-            "description": "32 bytes encoded in hexadecimal.",
-            "type": "string",
-            "pattern": "pattern": "^[a-fA-F0-9]{64}$"
+            "$ref": "#/components/schemas/TransactionId"
           },
           "locked": {
             "type": "boolean"
@@ -771,6 +766,11 @@
         "description": "Transaction encoded in hexadecimal.",
         "type": "string"
       },
+      "TransactionId": {
+        "description": "32 bytes encoded in hexadecimal; hash of transaction.",
+        "type": "string",
+        "pattern": "^[a-fA-F0-9]{64}$"
+      },
       "NanoContract": {
         "type": "object",
         "allOf": [
@@ -780,6 +780,7 @@
           {
             "properties": {
               "id": {
+                "description": "Refers to blueprint_id when method is initialize; refers to nc_id otherwise.",
                 "type": "string"
               },
               "method": {
@@ -844,7 +845,7 @@
             }
           },
           "hash": {
-            "type": "string"
+            "$ref": "#/components/schemas/TransactionId"
           }
         }
       },
@@ -852,8 +853,8 @@
         "type": "object",
         "properties": {
           "hash": {
-            "title": "Hash of transaction being spent",
-            "type": "string"
+            "title": "Hash of transaction's UTXO being spent",
+            "$ref": "#/components/schemas/TransactionId"
           },
           "index": {
             "title": "Index of outputs array from output being spent",
@@ -881,7 +882,7 @@
       },
       "Buffer": {
         "type": "string"
-      }
+      },
     },
     "errors":{
       "NotImplementedError": {

--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -20,7 +20,7 @@
       "params": [],
       "result": {
         "name": "ConnectedNetwork",
-        "summary": "Object containing network name and genesis hash",
+        "summary": "Provides network name and genesis hash",
         "schema": {
           "type": "object",
           "properties": {
@@ -185,63 +185,35 @@
           "summary": "Selects only UTXOs of the specified address",
           "required": true,
           "schema": {
-            "type": "string"
+            "$ref": "#/components/schemas/Address"
           }
         },
         {
           "name": "authorities",
           "summary": "Selects only UTXOs with specified authority",
           "schema": {
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "number"
           }
         },
         {
           "name": "amountSmallerThan",
           "summary": "Selects only UTXOs smaller than specified amount",
           "schema": {
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "number"
           }
         },
         {
           "name": "amountBiggerThan",
           "summary": "Selects only UTXOs greater than specified amount",
           "schema": {
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "number"
           }
         },
         {
           "name": "maximumAmount",
           "summary": "Returns only UTXOs smaller or equal than specified amount",
           "schema": {
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "number"
           }
         }
       ],
@@ -314,8 +286,8 @@
     },
     {
       "name": "htr_sendNanoContractTx",
-      "summary": "TO DO",
-      "description": "TO DO",
+      "summary": "Requests user to create or execute a contract",
+      "description": "Provides user the details for a contract creation or execution. dApp provides wallet application with data that comprises a contract creation/execution. Wallet application assembles and signs transaction, and then pushes it to network or returns it to dApp.",
       "paramStructure": "by-name",
       "params": [
         {
@@ -328,30 +300,28 @@
         },
         {
           "name": "blueprint_id",
-          "summary": "TO DO",
+          "summary": "Id of blueprint to instantiate new contract",
+          "description": "Should be used with method initialize, to create new contract. Should not be used with any other method.",
           "required": true,
           "schema": {
-            "type": "string"
+            "description": "32 bytes encoded in hexadecimal.",
+            "type": "string",
+            "pattern": "^[a-fA-F0-9]{64}$"
           }
         },
         {
           "name": "nc_id",
-          "summary": "TO DO",
-          "required": true,
+          "summary": "Id of contract being called",
+          "description": "Should be used for any method different than initialize, to execute a contract. Should not be used with method initialize."
           "schema": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "description": "32 bytes encoded in hexadecimal.",
+            "type": "string",
+            "pattern": "^[a-fA-F0-9]{64}$"
           }
         },
         {
           "name": "actions",
-          "summary": "TO DO",
+          "summary": "Set of deposits and withdrawals to be performed to/from the contract",
           "required": true,
           "schema": {
             "type": "array",
@@ -362,7 +332,7 @@
         },
         {
           "name": "args",
-          "summary": "TO DO",
+          "summary": "Arguments of method being called",
           "required": true,
           "schema": {
             "type": "array"
@@ -370,7 +340,7 @@
         },
         {
           "name": "push_tx",
-          "summary": "TO DO",
+          "description": "If true, wallet application signs transaction and pushs it to network. If false, wallet application returns signed transaction to dApp (ready to be pushed).",
           "required": true,
           "schema": {
             "type": "boolean"
@@ -383,9 +353,11 @@
           "type": "object",
           "oneOf": [
             {
-              "$ref": "#/components/schemas/SendTransaction"
+              "description": "If push_tx parameter was false, wallet application returns transaction encoded in hexadecimal, ready to be pushed by any one."
+              "$ref": "#/components/schemas/TransactionHex"
             },
             {
+              "description": "If push_tx parameter was true, wallet application returns the transaction already registered in the blockchain."
               "$ref": "#/components/schemas/NanoContract"
             }
           ]
@@ -405,21 +377,28 @@
     },
     {
       "name": "htr_createToken",
-      "summary": "TO DO",
+      "summary": "Requests user to create token",
+      "description": "Provides user the deailts for a token creation. dApp provides wallet application with data that comprises a token creation. Wallet application assembles and signs transaction, and then pushes it to network or returns it to dApp.",
       "paramStructure": "by-name",
       "params": [
         {
           "name": "name",
           "required": true,
           "schema": {
-            "type": "string"
+            "description": "UTF-8 characters.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 30
           }
         },
         {
           "name": "symbol",
           "required": true,
           "schema": {
-            "type": "string"
+            "description": "UTF-8 characters.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 5
           }
         },
         {
@@ -431,7 +410,7 @@
         },
         {
           "name": "address",
-          "summary": "TO DO",
+          "summary": "Destination for created amount of new token",
           "schema": {
             "$ref": "#/components/schemas/Address"
           }
@@ -444,7 +423,6 @@
         },
         {
           "name": "create_mint",
-          "summary": "TO DO",
           "required": true,
           "schema": {
             "type": "boolean"
@@ -452,21 +430,18 @@
         },
         {
           "name": "mint_authority_address",
-          "summary": "TO DO",
           "schema": {
-            "type": "string"
+            "$ref": "#/components/schemas/Address"
           }
         },
         {
           "name": "allow_external_mint_authority_address",
-          "summary": "TO DO",
           "schema": {
             "type": "boolean"
           }
         },
         {
           "name": "create_melt",
-          "summary": "TO DO",
           "required": true,
           "schema": {
             "type": "boolean"
@@ -474,21 +449,19 @@
         },
         {
           "name": "melt_authority_address",
-          "summary": "TO DO",
           "schema": {
-            "type": "string"
+            "$ref": "#/components/schemas/Address"
           }
         },
         {
           "name": "allow_external_melt_authority_address",
-          "summary": "TO DO",
           "schema": {
             "type": "boolean"
           }
         },
         {
           "name": "push_tx",
-          "summary": "TO DO",
+          "summary": "If true, wallet application signs transaction and pushs it to network. If false, wallet application returns signed transaction to dApp (ready to be pushed).",
           "required": true,
           "schema": {
             "type": "boolean"
@@ -499,7 +472,6 @@
         },
         {
           "name": "data",
-          "summary": "TO DO",
           "schema": {
             "type": "array",
             "items": {
@@ -511,7 +483,17 @@
       "result": {
         "name": "CreateTokenResponse",
         "schema": {
-          "$ref": "#/components/schemas/Transaction"
+          "type": "object",
+          "oneOf": [
+            {
+              "description": "If push_tx parameter was false, wallet application returns transaction encoded in hexadecimal, ready to be pushed by any one."
+              "$ref": "#/components/schemas/TransactionHex"
+            },
+            {
+              "description": "If push_tx parameter was true, wallet application returns the transaction already registered in the blockchain."
+              "$ref": "#/components/schemas/Transaction"
+            }
+          ]
         }
       },
       "errors": [
@@ -528,7 +510,8 @@
     },
     {
       "name": "htr_signOracleData",
-      "summary": "TO DO",
+      "summary": "Requests oracle to sign data",
+      "description": "Provides an oracle user data to be signed and that a contract requires to work. dApp provides wallet application with data to be signed. Wallet application returns signed data.",
       "paramStructure": "by-name",
       "params": [
         {
@@ -536,7 +519,6 @@
         },
         {
           "name": "data",
-          "summary": "TO DO",
           "required": true,
           "schema": {
             "type": "string"
@@ -544,7 +526,6 @@
         },
         {
           "name": "address",
-          "summary": "TO DO",
           "required": true,
           "schema": {
             "$ref": "#/components/schemas/Address"
@@ -553,7 +534,6 @@
       ],
       "result": {
         "name": "SignOracleDataResponse",
-        "summary": "TO DO",
         "schema": {
           "type": "object",
           "properties": {
@@ -604,7 +584,9 @@
         ]
       },
       "Token": {
-        "type": "string"
+        "description": "32 bytes encoded in hexadecimal.",
+        "type": "string",
+        "pattern": "^[a-fA-F0-9]{64}$"
       },
       "GetBalanceObject": {
         "type": "object",
@@ -625,14 +607,7 @@
           },
           "lockExpires": {
             "title": "When next lock expires, if has a timelock",
-            "oneOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "number"
           }
         }
       },
@@ -640,13 +615,21 @@
         "type": "object",
         "properties": {
           "id": {
-            "type": "string"
+            "description": "32 bytes encoded in hexadecimal.",
+            "type": "string",
+            "pattern": "^[a-fA-F0-9]{64}$"
           },
           "name": {
-            "type": "string"
+            "description": "UTF-8 characters.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 30
           },
           "symbol": {
-            "type": "string"
+            "description": "UTF-8 characters.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 5
           }
         }
       },
@@ -693,7 +676,9 @@
         }
       },
       "Address": {
-        "type": "string"
+        "description": "20 bytes encoded in base58check.",
+        "type": "string",
+        "pattern": "^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{34}$"
       },
       "UtxoDetails": {
         "type": "object",
@@ -722,13 +707,15 @@
         "type": "object",
         "properties": {
           "address": {
-            "type": "string"
+            "$ref": "#/components/schemas/Address"
           },
           "amount": {
-            "type": "string"
+            "type": "number"
           },
           "tx_id": {
-            "type": "string"
+            "description": "32 bytes encoded in hexadecimal.",
+            "type": "string",
+            "pattern": "pattern": "^[a-fA-F0-9]{64}$"
           },
           "locked": {
             "type": "boolean"
@@ -742,8 +729,7 @@
         "type": "object",
         "properties": {
           "address": {
-            "title": "Address in base58",
-            "type": "string"
+            "$ref": "#/components/schemas/Address"
           },
           "index": {
             "title": "Derivation index of the address",
@@ -781,8 +767,9 @@
           }
         }
       },
-      "SendTransaction": {
-        "type": "object"
+      "TransactionHex": {
+        "description": "Transaction encoded in hexadecimal.",
+        "type": "string"
       },
       "NanoContract": {
         "type": "object",

--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -1,8 +1,8 @@
 {
   "openrpc": "1.3.2",
   "info": {
-    "title": "Hathor wallet-to-dApp API",
-    "description": "API exposed by wallet applications for integration with dApps on Hathor platform.",
+    "title": "Hathor wallet-to-DApp API",
+    "description": "API exposed by wallet applications for integration with DApps on Hathor platform.",
     "contact": {
       "name": "Hathor Labs",
       "url": "https://docs.hathor.network/references/besides-documentation#support"
@@ -11,7 +11,7 @@
       "name": "MIT",
       "url": "https://github.com/HathorNetwork/hathor-rpc-lib/blob/release/LICENSE"
     },
-    "version": "0.1.0"
+    "version": "0.0.3-experimental-alpha"
   },
   "methods": [
     {
@@ -287,7 +287,7 @@
     {
       "name": "htr_sendNanoContractTx",
       "summary": "Requests user to create or execute a contract",
-      "description": "Provides user the details for a contract creation or execution. dApp provides wallet application with data that comprises a contract creation/execution. Wallet application assembles and signs transaction, and then pushes it to network or returns it to dApp.",
+      "description": "Provides user the details for a contract creation or execution. DApp provides wallet application with data that comprises a contract creation/execution. Wallet application assembles and signs transaction, and then pushes it to network or returns it to DApp.",
       "paramStructure": "by-name",
       "params": [
         {
@@ -340,7 +340,7 @@
         },
         {
           "name": "push_tx",
-          "description": "If true, wallet application signs transaction and pushs it to network. If false, wallet application returns signed transaction to dApp (ready to be pushed).",
+          "description": "If true, wallet application signs transaction and pushs it to network. If false, wallet application returns signed transaction to DApp (ready to be pushed).",
           "required": true,
           "schema": {
             "type": "boolean"
@@ -378,7 +378,7 @@
     {
       "name": "htr_createToken",
       "summary": "Requests user to create token",
-      "description": "Provides user the details for a token creation. dApp provides wallet application with data that comprises a token creation. Wallet application assembles and signs transaction, and then pushes it to network or returns it to dApp.",
+      "description": "Provides user the details for a token creation. DApp provides wallet application with data that comprises a token creation. Wallet application assembles and signs transaction, and then pushes it to network or returns it to DApp.",
       "paramStructure": "by-name",
       "params": [
         {
@@ -461,7 +461,7 @@
         },
         {
           "name": "push_tx",
-          "summary": "If true, wallet application signs transaction and pushs it to network. If false, wallet application returns signed transaction to dApp (ready to be pushed).",
+          "summary": "If true, wallet application signs transaction and pushs it to network. If false, wallet application returns signed transaction to DApp (ready to be pushed).",
           "required": true,
           "schema": {
             "type": "boolean"
@@ -511,7 +511,7 @@
     {
       "name": "htr_signOracleData",
       "summary": "Requests oracle to sign data",
-      "description": "Provides an oracle user data to be signed and that a contract requires to work. dApp provides wallet application with data to be signed. Wallet application returns signed data.",
+      "description": "Provides an oracle user data to be signed and that a contract requires to work. DApp provides wallet application with data to be signed. Wallet application returns signed data.",
       "paramStructure": "by-name",
       "params": [
         {
@@ -895,7 +895,7 @@
       },
       "PromptRejectedError": {
         "code": -31003,
-        "message": "User rejects confirmation prompt to reply dApp request"
+        "message": "User rejects confirmation prompt to reply DApp request"
       },
       "NCBadRequest": {
         "code": -31004,

--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -405,7 +405,7 @@
           "name": "amount",
           "required": true,
           "schema": {
-            "type": "number"
+            "$ref": "#/components/schemas/OutputValueType"
           }
         },
         {

--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -1,0 +1,930 @@
+{
+  "openrpc": "1.3.2",
+  "info": {
+    "title": "Hathor wallet-to-dApp API",
+    "description": "API exposed by wallet applications for integration with dApps on Hathor platform.",
+    "contact": {
+      "name": "Hathor Labs",
+      "url": "https://docs.hathor.network/references/besides-documentation#support"
+    },
+    "license": {
+      "name": "MIT",
+      "url": "https://github.com/HathorNetwork/hathor-rpc-lib/blob/release/LICENSE"
+    },
+    "version": "0.1.0"
+  },
+  "methods": [
+    {
+      "name": "htr_getConnectedNetwork",
+      "summary": "Returns the network to which the wallet is connected",
+      "params": [],
+      "result": {
+        "name": "ConnectedNetwork",
+        "summary": "Object containing network name and genesis hash",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "network": {
+              "$ref": "#/components/schemas/Network"
+            },
+            "genesisHash": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "htr_getBalance",
+      "summary": "Given an array of tokens, returns the balance of the wallet for each token",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "$ref": "#/components/contentDescriptors/Network"
+        },
+        {
+          "name": "tokens",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Token"
+            }
+          }
+        },
+        {
+          "name": "addressIndexes",
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "getBalanceObjects",
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/GetBalanceObject"
+          }
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/DifferentNetworkError"
+        },
+        {
+          "$ref": "#/components/errors/NotImplementedError"
+        },
+        {
+          "$ref": "#/components/errors/PromptRejectedError"
+        }
+      ]
+    },
+    {
+      "name": "htr_getAddress",
+      "summary": "Returns an address of the wallet",
+      "description": "Use the param 'type' to define how address should be selected.",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "$ref": "#/components/contentDescriptors/Network"
+        },
+        {
+          "name": "type",
+          "summary": "Define how the address should be selected",
+          "description": "Should be one of four possible values: 'first_empty', 'full_path', 'index', or 'client'.",
+          "required": true,
+          "schema": {
+            "oneOf": [
+              {
+                "const": "first_empty",
+                "description": "Use 'first_empty' to get the first address without transactions."
+              },
+              {
+                "const": "full_path",
+                "description": "Use 'full_path' to get an address given its full path."
+              },
+              {
+                "const": "index",
+                "description": "Use 'index' to get an address given its index in the wallet."
+              },
+              {
+                "const": "client",
+                "description": "Use 'client' to let the user select the address he/she wants to provide."
+              }
+            ]
+          }
+        },
+        {
+          "name": "full_path",
+          "summary": "Address full path in a wallet",
+          "description": "Should only be used alongside type 'full_path'.",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "index",
+          "summary": "Address index in a wallet",
+          "description": "Should only be used alongside type 'index'.",
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "result": {
+        "name": "address",
+        "schema": {
+          "$ref": "#/components/schemas/Address"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/DifferentNetworkError"
+        },
+        {
+          "$ref": "#/components/errors/NotImplementedError"
+        },
+        {
+          "$ref": "#/components/errors/PromptRejectedError"
+        }
+      ]
+    },
+    {
+      "name": "htr_getUtxos",
+      "summary": "Returns all UTXOs that meet the filter criteria",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "$ref": "#/components/contentDescriptors/Network"
+        },
+        {
+          "$ref": "#/components/contentDescriptors/Token"
+        },
+        {
+          "name": "maxUtxos",
+          "summary": "Limit number of UTXOs to be returned",
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        },
+        {
+          "name": "onlyAvailableUtxos",
+          "summary": "Selects only UTXOs available to be spent",
+          "required": true,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "filterAddress",
+          "summary": "Selects only UTXOs of the specified address",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "authorities",
+          "summary": "Selects only UTXOs with specified authority",
+          "schema": {
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        {
+          "name": "amountSmallerThan",
+          "summary": "Selects only UTXOs smaller than specified amount",
+          "schema": {
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        {
+          "name": "amountBiggerThan",
+          "summary": "Selects only UTXOs greater than specified amount",
+          "schema": {
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        {
+          "name": "maximumAmount",
+          "summary": "Returns only UTXOs smaller or equal than specified amount",
+          "schema": {
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      ],
+      "result": {
+        "name": "utxosDetails",
+        "summary": "Object with overall information about the set of UTXOs and an array of UTXOs",
+        "schema": {
+          "$ref": "#/components/schemas/UtxoDetails"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/DifferentNetworkError"
+        },
+        {
+          "$ref": "#/components/errors/PromptRejectedError"
+        }
+      ]
+    },
+    {
+      "name": "htr_signWithAddress",
+      "summary": "Given a message and an address, returns the correspondent signature",
+      "description": "Returns a message signed with the private key associated with the address, proving identity and/or authenticity.",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "$ref": "#/components/contentDescriptors/Network"
+        },
+        {
+          "name": "message",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "addressIndex",
+          "summary": "Address index in a wallet",
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        }
+      ],
+      "result": {
+        "name": "SignWithAddressResponse",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string"
+            },
+            "signature": {
+              "type": "string"
+            },
+            "address": {
+              "$ref": "#/components/schemas/AddressInfoObject"
+            }
+          }
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/DifferentNetworkError"
+        },
+        {
+          "$ref": "#/components/errors/PromptRejectedError"
+        }
+      ]
+    },
+    {
+      "name": "htr_sendNanoContractTx",
+      "summary": "TO DO",
+      "description": "TO DO",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "method",
+          "summary": "Method from contract or blueprint that should be called",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "blueprint_id",
+          "summary": "TO DO",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "nc_id",
+          "summary": "TO DO",
+          "required": true,
+          "schema": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        {
+          "name": "actions",
+          "summary": "TO DO",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NanoContractAction"
+            }
+          }
+        },
+        {
+          "name": "args",
+          "summary": "TO DO",
+          "required": true,
+          "schema": {
+            "type": "array"
+          }
+        },
+        {
+          "name": "push_tx",
+          "summary": "TO DO",
+          "required": true,
+          "schema": {
+            "type": "boolean"
+          }
+        }
+      ],
+      "result": {
+        "name": "SendNanoContractTxResponse",
+        "schema": {
+          "type": "object",
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/SendTransaction"
+            },
+            {
+              "$ref": "#/components/schemas/NanoContract"
+            }
+          ]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/NCBadRequest"
+        },
+        {
+          "$ref": "#/components/errors/PromptRejectedError"
+        },
+        {
+          "$ref": "#/components/errors/SendNanoContractTxFailure"
+        }
+      ]
+    },
+    {
+      "name": "htr_createToken",
+      "summary": "TO DO",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "name",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "symbol",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "amount",
+          "required": true,
+          "schema": {
+            "type": "number"
+          }
+        },
+        {
+          "name": "address",
+          "summary": "TO DO",
+          "schema": {
+            "$ref": "#/components/schemas/Address"
+          }
+        },
+        {
+          "name": "change_address",
+          "schema": {
+            "$ref": "#/components/schemas/Address"
+          }
+        },
+        {
+          "name": "create_mint",
+          "summary": "TO DO",
+          "required": true,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "mint_authority_address",
+          "summary": "TO DO",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "allow_external_mint_authority_address",
+          "summary": "TO DO",
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "create_melt",
+          "summary": "TO DO",
+          "required": true,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "melt_authority_address",
+          "summary": "TO DO",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "allow_external_melt_authority_address",
+          "summary": "TO DO",
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "push_tx",
+          "summary": "TO DO",
+          "required": true,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "$ref": "#/components/contentDescriptors/Network"
+        },
+        {
+          "name": "data",
+          "summary": "TO DO",
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "CreateTokenResponse",
+        "schema": {
+          "$ref": "#/components/schemas/Transaction"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/ChangeAddressError"
+        },
+        {
+          "$ref": "#/components/errors/PromptRejectedError"
+        },
+        {
+          "$ref": "#/components/errors/CreateTokenError"
+        }
+      ]
+    },
+    {
+      "name": "htr_signOracleData",
+      "summary": "TO DO",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "$ref": "#/components/contentDescriptors/Network"
+        },
+        {
+          "name": "data",
+          "summary": "TO DO",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "address",
+          "summary": "TO DO",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/Address"
+          }
+        }
+      ],
+      "result": {
+        "name": "SignOracleDataResponse",
+        "summary": "TO DO",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "data": {
+              "type": "string"
+            },
+            "signature": {
+              "type": "string"
+            },
+            "oracle": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/DifferentNetworkError"
+        },
+        {
+          "$ref": "#/components/errors/PromptRejectedError"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "contentDescriptors": {
+      "Network": {
+        "name": "network",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/Network"
+        }
+      },
+      "Token": {
+        "name": "token",
+        "required": true,
+        "schema": {
+          "$ref": "#/components/schemas/Token"
+        }
+      }
+    },
+    "schemas": {
+      "Network": {
+        "enum": [
+          "testnet",
+          "mainnet"
+        ]
+      },
+      "Token": {
+        "type": "string"
+      },
+      "GetBalanceObject": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "$ref": "#/components/schemas/TokenInfo"
+          },
+          "balance": {
+            "$ref": "#/components/schemas/Balance"
+          },
+          "tokenAuthorities": {
+            "title": "Authorities mint/melt availability",
+            "$ref": "#/components/schemas/AuthoritiesBalance"
+          },
+          "transactions": {
+            "title": "quantity of transactions",
+            "type": "number"
+          },
+          "lockExpires": {
+            "title": "When next lock expires, if has a timelock",
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "TokenInfo": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "symbol": {
+            "type": "string"
+          }
+        }
+      },
+      "Balance": {
+        "type": "object",
+        "properties": {
+          "unlocked": {
+            "title": "Available amount",
+            "$ref": "#/components/schemas/OutputValueType"
+          },
+          "locked": {
+            "title": "Locked amount",
+            "$ref": "#/components/schemas/OutputValueType"
+          }
+        }
+      },
+      "OutputValueType": {
+        "type": "number"
+      },
+      "AuthoritiesBalance": {
+        "type": "object",
+        "properties": {
+          "unlocked": {
+            "title": "unlocked mint/melt",
+            "$ref": "#/components/schemas/Authority"
+          },
+          "locked": {
+            "title": "locked mint/melt",
+            "$ref": "#/components/schemas/Authority"
+          }
+        }
+      },
+      "Authority": {
+        "type": "object",
+        "properties": {
+          "mint": {
+            "title": "if has mint authority",
+            "type": "boolean"
+          },
+          "melt": {
+            "title": "if has melt authority",
+            "type": "boolean"
+          }
+        }
+      },
+      "Address": {
+        "type": "string"
+      },
+      "UtxoDetails": {
+        "type": "object",
+        "properties": {
+          "total_amount_available": {
+            "type": "number"
+          },
+          "total_utxos_available": {
+            "type": "number"
+          },
+          "total_amount_locked": {
+            "type": "number"
+          },
+          "total_utxos_locked": {
+            "type": "number"
+          },
+          "utxos": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UtxoInfo"
+            }
+          }
+        }
+      },
+      "UtxoInfo": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "string"
+          },
+          "tx_id": {
+            "type": "string"
+          },
+          "locked": {
+            "type": "boolean"
+          },
+          "index": {
+            "type": "number"
+          }
+        }
+      },
+      "AddressInfoObject": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "title": "Address in base58",
+            "type": "string"
+          },
+          "index": {
+            "title": "Derivation index of the address",
+            "type": "number"
+          },
+          "addressPath": {
+            "title": "Path of the address",
+            "type": "string"
+          },
+          "info": {
+            "title": "Optional extra info when getting address info",
+            "type": "null"
+          }
+        }
+      },
+      "NanoContractAction": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": ["deposit", "withdrawal"]
+          },
+          "token": {
+            "$ref": "#/components/schemas/Token"
+          },
+          "amount": {
+            "$ref": "#/components/schemas/OutputValueType"
+          },
+          "address": {
+            "description": "When action type is 'withdrawal', address is required and specifies the destination for sending the output. When action type is 'deposit', address is optional and specifies the source from UTXOs.",
+            "$ref": "#/components/schemas/Address"
+          },
+          "changeAddress": {
+            "description": "When action type is 'deposit', change addess is optional and specifies the destination for the change output after selecting UTXOs. When action type is 'withdrawal', it is ignored.",
+            "$ref": "#/components/schemas/Address"
+          }
+        }
+      },
+      "SendTransaction": {
+        "type": "object"
+      },
+      "NanoContract": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Transaction"
+          },
+          {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "method": {
+                "type": "string"
+              },
+              "args": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Buffer"
+                }
+              },
+              "pubkey": {
+                "$ref": "#/components/schemas/Buffer"
+              },
+              "signature": {
+                "$ref": "#/components/schemas/Buffer"
+              }
+            }
+          }
+        ]
+      },
+      "Transaction": {
+        "type": "object",
+        "properties": {
+          "inputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Input"
+            }
+          },
+          "outputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Output"
+            }
+          },
+          "signalBits": {
+            "type": "number"
+          },
+          "version": {
+            "type": "number"
+          },
+          "weight": {
+            "type": "number"
+          },
+          "nonce": {
+            "type": "number"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "parents": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tokens": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Token"
+            }
+          },
+          "hash": {
+            "type": "string"
+          }
+        }
+      },
+      "Input": {
+        "type": "object",
+        "properties": {
+          "hash": {
+            "title": "Hash of transaction being spent",
+            "type": "string"
+          },
+          "index": {
+            "title": "Index of outputs array from output being spent",
+            "type": "number"
+          },
+          "data": {
+            "title": "Input signed data for P2PKH and redeemScript for P2SH",
+            "$ref": "#/components/schemas/Buffer"
+          }
+        }
+      },
+      "Output": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/OutputValueType"
+          },
+          "tokenData": {
+            "type": "number"
+          },
+          "script": {
+            "$ref": "#/components/schemas/Buffer"
+          }
+        }
+      },
+      "Buffer": {
+        "type": "string"
+      }
+    },
+    "errors":{
+      "NotImplementedError": {
+        "code": -31001,
+        "message": "Feature not implemented"
+      },
+      "DifferentNetworkError": {
+        "code": -31002,
+        "message": "Wallet not connected to requested network"
+      },
+      "PromptRejectedError": {
+        "code": -31003,
+        "message": "User rejects confirmation prompt to reply dApp request"
+      },
+      "NCBadRequest": {
+        "code": -31004,
+        "message": "Neither blueprint id nor NC id available"
+      },
+      "SendNanoContractTxFailure": {
+        "code": -31005,
+        "message": "NC tx failed"
+      },
+      "ChangeAddressError": {
+        "code": -31006,
+        "message": "Change address is not from this wallet"
+      },
+      "CreateTokenError": {
+        "code": -31007,
+        "message": "Error creating token"
+      }
+    }
+  }
+}


### PR DESCRIPTION

Objective:
- Document the API exposed by wallet applications to communicate with dApps on the Hathor platform.
- API type: JSON-RPC 2.0.
- API documented using the Open RPC standard.
- API documented in the `openrpc.json` file.
- The file should be used to automatically generate documentation on the Hathor docs website, similar to how it is already done with the full node and headless APIs.
- The final format that will be used is still being defined.
- For now, the following format can be used as a minimum standard to be used, but it should still improve the UI/UX:

https://beta-test.docs.hathor.network/references/dapps/rpc-api/htr_getBalance

Only one file to be reviewed: `openrpc.json`