### PR TITLE
fix: added missing create token to exports and added createToken rpc

### DIFF
--- a/packages/hathor-rpc-handler/src/rpcMethods/index.ts
+++ b/packages/hathor-rpc-handler/src/rpcMethods/index.ts
@@ -5,3 +5,4 @@ export * from './sendNanoContractTx';
 export * from './signWithAddress';
 export * from './getConnectedNetwork';
 export * from './signOracleData';
+export * from './createToken';

--- a/packages/hathor-rpc-handler/src/rpcRequest/createToken.ts
+++ b/packages/hathor-rpc-handler/src/rpcRequest/createToken.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { RpcMethods, CreateTokenRpcRequest } from '../types';
+
+export function createTokenRpcRequest(
+  pushTx: boolean,
+  network: string,
+  name: string,
+  symbol: string,
+  amount: number,
+  address?: string,
+  createMint: boolean = true,
+  createMelt: boolean = true,
+  allowExternalMintAuthorityAddress: boolean = false,
+  allowExternalMeltAuthorityAddress: boolean = false,
+  changeAddress?: string,
+  mintAuthorityAddress?: string,
+  meltAuthorityAddress?: string,
+  data?: string[],
+): CreateTokenRpcRequest {
+  return {
+    method: RpcMethods.CreateToken,
+    params: {
+      push_tx: pushTx,
+      network,
+      name,
+      symbol,
+      amount,
+      create_mint: createMint,
+      create_melt: createMelt,
+      allow_external_mint_authority_address: allowExternalMintAuthorityAddress,
+      allow_external_melt_authority_address: allowExternalMeltAuthorityAddress,
+      address,
+      change_address: changeAddress,
+      mint_authority_address: mintAuthorityAddress,
+      data,
+      melt_authority_address: meltAuthorityAddress
+    }
+  };
+}

--- a/packages/hathor-rpc-handler/src/rpcRequest/index.ts
+++ b/packages/hathor-rpc-handler/src/rpcRequest/index.ts
@@ -1,3 +1,4 @@
 export * from './sendNanoContractTx';
 export * from './signWithAddress';
 export * from './signOracleData';
+export * from './createToken';


### PR DESCRIPTION
## Acceptance Criteria

- We should export the `createToken` rpcMethod in the index file so it's imported directly
- Added a dApp helper to create a create token rpc request