### PR TITLE
chore(versioning): fix versioning of the package

### DIFF
--- a/packages/hathor-rpc-handler/package.json
+++ b/packages/hathor-rpc-handler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hathor/hathor-rpc-handler",
   "license": "MIT",
-  "version": "0.0.3-experimental-alpha",
+  "version": "0.3.0-experimental-alpha",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
**PR Objective:**
Correct initial package versioning.

The initial versioning of the package was started at: 0.0.1

This does not follow the semantic versioning standard.

Following the semantic versioning standard [https://semver.org](https://semver.org/), the first version released, even if still in the development phase, should be 0.1.0 and from then on, increment the minor version for each subsequent release.

In other words: the first version should start counting with the minor version and not with the patch.

According to: [https://semver.org/#how-should-i-deal-with-revisions-in-the-0yz-initial-development-phase](https://semver.org/#how-should-i-deal-with-revisions-in-the-0yz-initial-development-phase)

Suggested change made:
- Replace the current version from: 0.0.3-experimental-alpha
- To: 0.3.0-experimental-alpha