### PR TITLE
feat: specific prepare tx error

### DIFF
--- a/packages/hathor-rpc-handler/src/errors/index.ts
+++ b/packages/hathor-rpc-handler/src/errors/index.ts
@@ -49,6 +49,13 @@ export class InvalidParamTypeError extends Error {
   }
 }
 
+export class PrepareSendTransactionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PrepareSendTransactionError';
+  }
+}
+
 export class SendTransactionError extends Error {
   constructor(message: string) {
     super(message);

--- a/packages/hathor-rpc-handler/src/rpcMethods/sendTransaction.ts
+++ b/packages/hathor-rpc-handler/src/rpcMethods/sendTransaction.ts
@@ -27,6 +27,7 @@ import {
   InvalidParamsError,
   SendTransactionError,
   InsufficientFundsError,
+  PrepareSendTransactionError,
 } from '../errors';
 import { validateNetwork } from '../helpers';
 
@@ -131,7 +132,7 @@ export async function sendTransaction(
         throw new InsufficientFundsError(err.message);
       }
     }
-    throw new SendTransactionError(err instanceof Error ? err.message : 'An unknown error occurred while preparing the transaction');
+    throw new PrepareSendTransactionError(err instanceof Error ? err.message : 'An unknown error occurred while preparing the transaction');
   }
 
   // Show the complete transaction (with all inputs) to the user


### PR DESCRIPTION
### Motivation

We should have a specific error for when the transaction fails while being prepared, the idea is to differentiate it from the `SendTransactionError` (which happens after the transaction is displayed to the user) 

### Acceptance Criteria

- Throw a specific error for failures in the prepareTx phase

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
