### PR TITLE
chore: updated openrpc with sendTransaction

### DIFF
--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -312,7 +312,7 @@
         {
           "name": "nc_id",
           "summary": "Id of contract being called",
-          "description": "Should be used for any method different than initialize, to execute a contract. Should not be used with method initialize."
+          "description": "Should be used for any method different than initialize, to execute a contract. Should not be used with method initialize.",
           "schema": {
             "description": "32 bytes encoded in hexadecimal.",
             "type": "string",
@@ -353,11 +353,11 @@
           "type": "object",
           "oneOf": [
             {
-              "description": "If push_tx parameter was false, wallet application returns transaction encoded in hexadecimal, ready to be pushed by any one."
+              "description": "If push_tx parameter was false, wallet application returns transaction encoded in hexadecimal, ready to be pushed by any one.",
               "$ref": "#/components/schemas/TransactionHex"
             },
             {
-              "description": "If push_tx parameter was true, wallet application returns the transaction already registered in the blockchain."
+              "description": "If push_tx parameter was true, wallet application returns the transaction already registered in the blockchain.",
               "$ref": "#/components/schemas/NanoContract"
             }
           ]
@@ -404,9 +404,7 @@
         {
           "name": "amount",
           "required": true,
-          "schema": {
-            "$ref": "#/components/schemas/OutputValueType"
-          }
+          "type": "string"
         },
         {
           "name": "address",
@@ -486,11 +484,11 @@
           "type": "object",
           "oneOf": [
             {
-              "description": "If push_tx parameter was false, wallet application returns transaction encoded in hexadecimal, ready to be pushed by any one."
+              "description": "If push_tx parameter was false, wallet application returns transaction encoded in hexadecimal, ready to be pushed by any one.",
               "$ref": "#/components/schemas/TransactionHex"
             },
             {
-              "description": "If push_tx parameter was true, wallet application returns the transaction already registered in the blockchain."
+              "description": "If push_tx parameter was true, wallet application returns the transaction already registered in the blockchain.",
               "$ref": "#/components/schemas/Transaction"
             }
           ]
@@ -555,6 +553,101 @@
         },
         {
           "$ref": "#/components/errors/PromptRejectedError"
+        }
+      ]
+    },
+    {
+      "name": "htr_sendTransaction",
+      "summary": "Sends a transaction",
+      "description": "Sends tokens to multiple addresses and creates data outputs. This method allows creating transactions with multiple outputs. DApp provides wallet application with output details, and optionally specific inputs to use. Wallet application assembles, signs, and sends the transaction.",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "$ref": "#/components/contentDescriptors/Network"
+        },
+        {
+          "name": "outputs",
+          "summary": "List of transaction outputs to create",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "address": {
+                  "description": "Destination address for the tokens",
+                  "$ref": "#/components/schemas/Address"
+                },
+                "value": {
+                  "description": "Amount of tokens to send",
+                  "type": "string"
+                },
+                "token": {
+                  "description": "Token UID, defaults to HTR if not specified",
+                  "$ref": "#/components/schemas/Token"
+                },
+                "type": {
+                  "description": "Output type, can be 'data' for data outputs",
+                  "type": "string"
+                },
+                "data": {
+                  "description": "Data string for data outputs",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "name": "inputs",
+          "summary": "Optional specific inputs to use in transaction",
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "txId": {
+                  "description": "Transaction ID of the input",
+                  "$ref": "#/components/schemas/TransactionId"
+                },
+                "index": {
+                  "description": "Output index in the transaction",
+                  "type": "number"
+                }
+              },
+              "required": ["txId", "index"]
+            }
+          }
+        },
+        {
+          "name": "changeAddress",
+          "summary": "Address to receive change from the transaction",
+          "schema": {
+            "$ref": "#/components/schemas/Address"
+          }
+        }
+      ],
+      "result": {
+        "name": "SendTransactionResponse",
+        "schema": {
+          "$ref": "#/components/schemas/Transaction"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/DifferentNetworkError"
+        },
+        {
+          "$ref": "#/components/errors/PromptRejectedError"
+        },
+        {
+          "$ref": "#/components/errors/SendTransactionError"
+        },
+        {
+          "$ref": "#/components/errors/InsufficientFundsError"
+        },
+        {
+          "$ref": "#/components/errors/PrepareSendTransactionError"
         }
       ]
     }
@@ -750,7 +843,7 @@
             "$ref": "#/components/schemas/Token"
           },
           "amount": {
-            "$ref": "#/components/schemas/OutputValueType"
+            "type": "string"
           },
           "address": {
             "description": "When action type is 'withdrawal', address is required and specifies the destination for sending the output. When action type is 'deposit', address is optional and specifies the source from UTXOs.",
@@ -882,7 +975,7 @@
       },
       "Buffer": {
         "type": "string"
-      },
+      }
     },
     "errors":{
       "NotImplementedError": {
@@ -912,6 +1005,18 @@
       "CreateTokenError": {
         "code": -31007,
         "message": "Error creating token"
+      },
+      "SendTransactionError": {
+        "code": -31008,
+        "message": "Error sending transaction"
+      },
+      "InsufficientFundsError": {
+        "code": -31009,
+        "message": "Insufficient funds"
+      },
+      "PrepareSendTransactionError": {
+        "code": -31010,
+        "message": "Error preparing transaction"
       }
     }
   }

--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -86,7 +86,7 @@
     {
       "name": "htr_getAddress",
       "summary": "Returns an address of the wallet",
-      "description": "Use the param 'type' to define how address should be selected.",
+      "description": "Use parameter 'type' to define how address should be selected.",
       "paramStructure": "by-name",
       "params": [
         {
@@ -131,7 +131,7 @@
           "summary": "Address index in a wallet",
           "description": "Should only be used alongside type 'index'.",
           "schema": {
-            "type": "number"
+            "type": "integer"
           }
         }
       ],
@@ -169,7 +169,7 @@
           "summary": "Limit number of UTXOs to be returned",
           "required": true,
           "schema": {
-            "type": "number"
+            "type": "integer"
           }
         },
         {
@@ -192,28 +192,28 @@
           "name": "authorities",
           "summary": "Selects only UTXOs with specified authority",
           "schema": {
-            "type": "number"
+            "type": "integer"
           }
         },
         {
           "name": "amountSmallerThan",
           "summary": "Selects only UTXOs smaller than specified amount",
           "schema": {
-            "type": "number"
+            "type": "integer"
           }
         },
         {
           "name": "amountBiggerThan",
           "summary": "Selects only UTXOs greater than specified amount",
           "schema": {
-            "type": "number"
+            "type": "integer"
           }
         },
         {
           "name": "maximumAmount",
           "summary": "Limit the maximum total amount to return summing all utxos",
           "schema": {
-            "type": "number"
+            "type": "integer"
           }
         }
       ],
@@ -254,7 +254,7 @@
           "summary": "Address index in a wallet",
           "required": true,
           "schema": {
-            "type": "number"
+            "type": "integer"
           }
         }
       ],
@@ -314,9 +314,7 @@
           "summary": "Id of contract being called",
           "description": "Should be used for any method different than initialize, to execute a contract. Should not be used with method initialize.",
           "schema": {
-            "description": "32 bytes encoded in hexadecimal.",
-            "type": "string",
-            "pattern": "^[a-fA-F0-9]{64}$"
+            "$ref": "#/components/schemas/TransactionId"
           }
         },
         {
@@ -509,7 +507,7 @@
     {
       "name": "htr_signOracleData",
       "summary": "Requests oracle to sign data",
-      "description": "Provides an oracle user data to be signed and that a contract requires to work. DApp provides wallet application with data to be signed. Wallet application returns signed data.",
+      "description": "Provides an oracle-user data to be signed and that a contract requires to work. DApp provides wallet application with data to be signed. Wallet application returns signed data.",
       "paramStructure": "by-name",
       "params": [
         {
@@ -558,8 +556,8 @@
     },
     {
       "name": "htr_sendTransaction",
-      "summary": "Sends a transaction",
-      "description": "Sends tokens to multiple addresses and creates data outputs. This method allows creating transactions with multiple outputs. DApp provides wallet application with output details, and optionally specific inputs to use. Wallet application assembles, signs, and sends the transaction.",
+      "summary": "Requests user to send transfers and/or record data outputs",
+      "description": "Provides user the details for performing token transfers and/or data registration (via data outputs) on ledger (blockchain). DApp provides wallet application with data that describes a single transaction comprised by token transfers, of multiple tokens, to multiple addresses; and by data outputs. Wallet application assembles and signs transaction, and then pushes it to network.",
       "paramStructure": "by-name",
       "params": [
         {
@@ -567,51 +565,64 @@
         },
         {
           "name": "outputs",
-          "summary": "List of transaction outputs to create",
+          "summary": "Set of token transfers and data outputs of the transaction",
           "required": true,
           "schema": {
             "type": "array",
             "items": {
               "type": "object",
-              "properties": {
-                "address": {
-                  "description": "Destination address for the tokens",
-                  "$ref": "#/components/schemas/Address"
+              "oneOf": [
+                {
+                  "description": "Output denotes a token transfer."
+                  "properties": {
+                    "value": {
+                      "description": "Amount of tokens to transfer.",
+                      "type": "string"
+                    },
+                    "token": {
+                      "description": "Token to be transferred; if not specified, defaults to HTR.",
+                      "default": "00",
+                      "$ref": "#/components/schemas/Token"
+                    },
+                    "address": {
+                      "description": "Recipient of token transfer.",
+                      "$ref": "#/components/schemas/Address"
+                    },
+                  },
+                  "required": ["value", "address"]
                 },
-                "value": {
-                  "description": "Amount of tokens to send",
-                  "type": "string"
-                },
-                "token": {
-                  "description": "Token UID, defaults to HTR if not specified",
-                  "$ref": "#/components/schemas/Token"
-                },
-                "type": {
-                  "description": "Output type, can be 'data' for data outputs",
-                  "type": "string"
-                },
-                "data": {
-                  "description": "Data string for data outputs",
-                  "type": "string"
+                {
+                  "description": "Output is a data output. Register arbitrary data on the blockchain."
+                  "properties": {
+                    "type": {
+                      "description": "Use to mark this output as data output."
+                      "const": "data"
+                    },
+                    "data": {
+                      "description": "Unit of information or data point to be registered on the ledger (blockchain).",
+                      "type": "string"
+                    },
+                  },
+                  "required": ["data"]
                 }
-              }
+              ]
             }
           }
         },
         {
           "name": "inputs",
-          "summary": "Optional specific inputs to use in transaction",
+          "summary": "Optional inputs selection — i.e., UTXOs to be spent.",
           "schema": {
             "type": "array",
             "items": {
               "type": "object",
               "properties": {
                 "txId": {
-                  "description": "Transaction ID of the input",
+                  "description": "Transaction hash whose UTXO is being spent.",
                   "$ref": "#/components/schemas/TransactionId"
                 },
                 "index": {
-                  "description": "Output index in the transaction",
+                  "description": "Index of outputs array from output being spent.",
                   "type": "number"
                 }
               },
@@ -621,7 +632,7 @@
         },
         {
           "name": "changeAddress",
-          "summary": "Address to receive change from the transaction",
+          "summary": "Destination for the change output after selecting UTXOs",
           "schema": {
             "$ref": "#/components/schemas/Address"
           }
@@ -690,15 +701,15 @@
             "$ref": "#/components/schemas/Balance"
           },
           "tokenAuthorities": {
-            "title": "Authorities mint/melt availability",
+            "description": "Authorities mint/melt availability.",
             "$ref": "#/components/schemas/AuthoritiesBalance"
           },
           "transactions": {
-            "title": "quantity of transactions",
-            "type": "number"
+            "description": "Quantity of transactions.",
+            "type": "integer"
           },
           "lockExpires": {
-            "title": "When next lock expires, if has a timelock",
+            "description": "When next lock expires, if has a timelock.",
             "type": "number"
           }
         }
@@ -727,11 +738,11 @@
         "type": "object",
         "properties": {
           "unlocked": {
-            "title": "Available amount",
+            "description": "Available amount.",
             "$ref": "#/components/schemas/OutputValueType"
           },
           "locked": {
-            "title": "Locked amount",
+            "description": "Locked amount.",
             "$ref": "#/components/schemas/OutputValueType"
           }
         }
@@ -743,11 +754,11 @@
         "type": "object",
         "properties": {
           "unlocked": {
-            "title": "unlocked mint/melt",
+            "description": "Unlocked mint/melt.",
             "$ref": "#/components/schemas/Authority"
           },
           "locked": {
-            "title": "locked mint/melt",
+            "description": "Locked mint/melt.",
             "$ref": "#/components/schemas/Authority"
           }
         }
@@ -756,11 +767,11 @@
         "type": "object",
         "properties": {
           "mint": {
-            "title": "if has mint authority",
+            "description": "If has mint authority.",
             "type": "boolean"
           },
           "melt": {
-            "title": "if has melt authority",
+            "description": "If has melt authority.",
             "type": "boolean"
           }
         }
@@ -820,15 +831,15 @@
             "$ref": "#/components/schemas/Address"
           },
           "index": {
-            "title": "Derivation index of the address",
+            "description": "Derivation index of the address.",
             "type": "number"
           },
           "addressPath": {
-            "title": "Path of the address",
+            "description": "Path of the address.",
             "type": "string"
           },
           "info": {
-            "title": "Optional extra info when getting address info",
+            "description": "Optional extra info when getting address info.",
             "type": "null"
           }
         }
@@ -839,11 +850,11 @@
           "type": {
             "enum": ["deposit", "withdrawal"]
           },
-          "token": {
-            "$ref": "#/components/schemas/Token"
-          },
           "amount": {
             "type": "string"
+          },
+          "token": {
+            "$ref": "#/components/schemas/Token"
           },
           "address": {
             "description": "When action type is 'withdrawal', address is required and specifies the destination for sending the output. When action type is 'deposit', address is optional and specifies the source from UTXOs.",
@@ -853,7 +864,8 @@
             "description": "When action type is 'deposit', change addess is optional and specifies the destination for the change output after selecting UTXOs. When action type is 'withdrawal', it is ignored.",
             "$ref": "#/components/schemas/Address"
           }
-        }
+        },
+        "required": ["type", "amount", "token"]
       },
       "TransactionHex": {
         "description": "Transaction encoded in hexadecimal.",
@@ -946,15 +958,15 @@
         "type": "object",
         "properties": {
           "hash": {
-            "title": "Hash of transaction's UTXO being spent",
+            "description": "Transaction hash whose UTXO is being spent.",
             "$ref": "#/components/schemas/TransactionId"
           },
           "index": {
-            "title": "Index of outputs array from output being spent",
+            "description": "Index of outputs array from output being spent.",
             "type": "number"
           },
           "data": {
-            "title": "Input signed data for P2PKH and redeemScript for P2SH",
+            "description": "Input signed data for P2PKH and redeemScript for P2SH.",
             "$ref": "#/components/schemas/Buffer"
           }
         }
@@ -1016,7 +1028,7 @@
       },
       "PrepareSendTransactionError": {
         "code": -31010,
-        "message": "Error preparing transaction"
+        "message": "Error assembling transaction"
       }
     }
   }

--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -592,10 +592,10 @@
                   "required": ["value", "address"]
                 },
                 {
-                  "description": "Output is a data output. Register arbitrary data on the blockchain."
+                  "description": "Output is a 'data output'. Register arbitrary data on the blockchain."
                   "properties": {
                     "type": {
-                      "description": "Use to mark this output as data output."
+                      "description": "Use to mark this output as a 'data output'."
                       "const": "data"
                     },
                     "data": {


### PR DESCRIPTION
### Motivation

The openrpc doc was outdated after the recent parameter changes

### Acceptance Criteria

- We should document the `htr_sendTransaction` RPC
- We should update the `value` and `amount` parameters for `htr_sendNanoContractTx` and `htr_createToken` as they're now strings.

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
