### PR TITLE
feat: added triggers for loading in createNanoContractCreateTokenTx

### DIFF
--- a/packages/hathor-rpc-handler/__tests__/rpcMethods/createNanoContractCreateTokenTx.test.ts
+++ b/packages/hathor-rpc-handler/__tests__/rpcMethods/createNanoContractCreateTokenTx.test.ts
@@ -117,15 +117,28 @@ describe('createNanoContractCreateTokenTx', () => {
 
     const result = await createNanoContractCreateTokenTx(rpcRequest, wallet, {}, promptHandler);
 
-    expect(promptHandler).toHaveBeenCalledWith(
+    expect(promptHandler).toHaveBeenCalledTimes(4); // Confirmation, PIN, Loading, LoadingFinished
+    expect(promptHandler).toHaveBeenNthCalledWith(1,
       expect.objectContaining({
         type: TriggerTypes.CreateNanoContractCreateTokenTxConfirmationPrompt,
       }),
       {}
     );
-    expect(promptHandler).toHaveBeenCalledWith(
+    expect(promptHandler).toHaveBeenNthCalledWith(2,
       expect.objectContaining({
         type: TriggerTypes.PinConfirmationPrompt,
+      }),
+      {}
+    );
+    expect(promptHandler).toHaveBeenNthCalledWith(3,
+      expect.objectContaining({
+        type: TriggerTypes.CreateNanoContractCreateTokenTxLoadingTrigger,
+      }),
+      {}
+    );
+    expect(promptHandler).toHaveBeenNthCalledWith(4,
+      expect.objectContaining({
+        type: TriggerTypes.CreateNanoContractCreateTokenTxLoadingFinishedTrigger,
       }),
       {}
     );
@@ -176,6 +189,21 @@ describe('createNanoContractCreateTokenTx', () => {
       });
     (wallet.createNanoContractCreateTokenTransaction as jest.Mock).mockResolvedValue(response);
     const result = await createNanoContractCreateTokenTx(rpcRequest, wallet, {}, promptHandler);
+    
+    expect(promptHandler).toHaveBeenCalledTimes(4); // Confirmation, PIN, Loading, LoadingFinished
+    expect(promptHandler).toHaveBeenNthCalledWith(3,
+      expect.objectContaining({
+        type: TriggerTypes.CreateNanoContractCreateTokenTxLoadingTrigger,
+      }),
+      {}
+    );
+    expect(promptHandler).toHaveBeenNthCalledWith(4,
+      expect.objectContaining({
+        type: TriggerTypes.CreateNanoContractCreateTokenTxLoadingFinishedTrigger,
+      }),
+      {}
+    );
+    
     expect(wallet.createNanoContractCreateTokenTransaction).toHaveBeenCalledWith(
       rpcRequest.params.method,
       rpcRequest.params.address,

--- a/packages/hathor-rpc-handler/src/rpcMethods/createNanoContractCreateTokenTx.ts
+++ b/packages/hathor-rpc-handler/src/rpcMethods/createNanoContractCreateTokenTx.ts
@@ -18,6 +18,8 @@ import {
   CreateNanoContractCreateTokenTxResponse,
   CreateNanoContractCreateTokenTxConfirmationPrompt,
   CreateNanoContractCreateTokenTxConfirmationResponse,
+  CreateNanoContractCreateTokenTxLoadingTrigger,
+  CreateNanoContractCreateTokenTxLoadingFinishedTrigger,
   NanoContractParams,
   CreateTokenParams,
 } from '../types';
@@ -125,6 +127,12 @@ export async function createNanoContractCreateTokenTx(
     throw new PromptRejectedError('User rejected PIN prompt');
   }
 
+  // Emit loading trigger
+  const loadingTrigger: CreateNanoContractCreateTokenTxLoadingTrigger = {
+    type: TriggerTypes.CreateNanoContractCreateTokenTxLoadingTrigger,
+  };
+  promptHandler(loadingTrigger, requestMetadata);
+
   // Call the wallet method
   let response;
   if (push_tx) {
@@ -144,6 +152,12 @@ export async function createNanoContractCreateTokenTx(
       { pinCode: pinResponse.data.pinCode }
     );
   }
+
+  // Emit loading finished trigger
+  const loadingFinishedTrigger: CreateNanoContractCreateTokenTxLoadingFinishedTrigger = {
+    type: TriggerTypes.CreateNanoContractCreateTokenTxLoadingFinishedTrigger,
+  };
+  promptHandler(loadingFinishedTrigger, requestMetadata);
 
   return {
     type: RpcResponseTypes.CreateNanoContractCreateTokenTxResponse,

--- a/packages/hathor-rpc-handler/src/types/prompt.ts
+++ b/packages/hathor-rpc-handler/src/types/prompt.ts
@@ -31,6 +31,8 @@ export enum TriggerTypes {
   SendTransactionLoadingTrigger,
   SendTransactionLoadingFinishedTrigger,
   CreateNanoContractCreateTokenTxConfirmationPrompt,
+  CreateNanoContractCreateTokenTxLoadingTrigger,
+  CreateNanoContractCreateTokenTxLoadingFinishedTrigger,
 }
 
 export enum TriggerResponseTypes {
@@ -67,7 +69,9 @@ export type Trigger =
   | SendTransactionConfirmationPrompt
   | SendTransactionLoadingTrigger
   | SendTransactionLoadingFinishedTrigger
-  | CreateNanoContractCreateTokenTxConfirmationPrompt;
+  | CreateNanoContractCreateTokenTxConfirmationPrompt
+  | CreateNanoContractCreateTokenTxLoadingTrigger
+  | CreateNanoContractCreateTokenTxLoadingFinishedTrigger;
 
 export interface BaseLoadingTrigger {
   type: TriggerTypes;
@@ -332,4 +336,12 @@ export interface SendTransactionLoadingTrigger extends BaseLoadingTrigger {
 
 export interface SendTransactionLoadingFinishedTrigger extends BaseLoadingTrigger {
   type: TriggerTypes.SendTransactionLoadingFinishedTrigger;
+}
+
+export interface CreateNanoContractCreateTokenTxLoadingTrigger extends BaseLoadingTrigger {
+  type: TriggerTypes.CreateNanoContractCreateTokenTxLoadingTrigger;
+}
+
+export interface CreateNanoContractCreateTokenTxLoadingFinishedTrigger extends BaseLoadingTrigger {
+  type: TriggerTypes.CreateNanoContractCreateTokenTxLoadingFinishedTrigger;
 }


### PR DESCRIPTION
### Motivation

We should emit a loading trigger to clients on `htr_createNanoContractCreateTokenTx`

### Acceptance Criteria

- We should have new types for emitting a loading trigger when creating a nano contract create token tx 

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
