### PR TITLE
refactor: returning a flat list of balances in htr_getBalance

### DIFF
--- a/packages/hathor-rpc-handler/__tests__/rpcMethods/getBalance.test.ts
+++ b/packages/hathor-rpc-handler/__tests__/rpcMethods/getBalance.test.ts
@@ -16,10 +16,27 @@ import { InvalidParamsError, NotImplementedError } from '../../src/errors';
 describe('getBalance parameter validation', () => {
   const mockWallet = {
     getNetwork: jest.fn().mockReturnValue('testnet'),
-    getBalance: jest.fn().mockResolvedValue({
-      available: 100,
-      locked: 0,
-    }),
+    getBalance: jest.fn().mockResolvedValue([{
+      token: {
+        id: '000003521effbc8efd7b746a118cdc7d41d7cc1bf9c5d1fa5de4f8453f14ba4f'
+      },
+      balance: {
+        unlocked: '0',
+        locked: '0'
+      },
+      transactions: 0,
+      lockExpires: null,
+      tokenAuthorities: {
+        unlocked: {
+          mint: '0',
+          melt: '0'
+        },
+        locked: {
+          mint: '0',
+          melt: '0'
+        }
+      }
+    }]),
   } as unknown as HathorWallet;
 
   const mockTriggerHandler = jest.fn().mockResolvedValue(true);
@@ -114,5 +131,72 @@ describe('getBalance parameter validation', () => {
     ).resolves.toBeDefined();
 
     expect(mockWallet.getBalance).toHaveBeenCalledWith('HTR');
+  });
+
+  it('should return flat array for multiple tokens', async () => {
+    const token1Balance = [{
+      token: {
+        id: '00'
+      },
+      balance: {
+        unlocked: '100',
+        locked: '0'
+      },
+      transactions: 10,
+      lockExpires: null,
+      tokenAuthorities: {
+        unlocked: {
+          mint: '0',
+          melt: '0'
+        },
+        locked: {
+          mint: '0',
+          melt: '0'
+        }
+      }
+    }];
+
+    const token2Balance = [{
+      token: {
+        id: '000003521effbc8efd7b746a118cdc7d41d7cc1bf9c5d1fa5de4f8453f14ba4f'
+      },
+      balance: {
+        unlocked: '50',
+        locked: '0'
+      },
+      transactions: 5,
+      lockExpires: null,
+      tokenAuthorities: {
+        unlocked: {
+          mint: '0',
+          melt: '0'
+        },
+        locked: {
+          mint: '0',
+          melt: '0'
+        }
+      }
+    }];
+
+    mockWallet.getBalance
+      .mockResolvedValueOnce(token1Balance)
+      .mockResolvedValueOnce(token2Balance);
+
+    const validRequest = {
+      method: RpcMethods.GetBalance,
+      params: {
+        network: 'testnet',
+        tokens: ['00', '000003521effbc8efd7b746a118cdc7d41d7cc1bf9c5d1fa5de4f8453f14ba4f'],
+      },
+    } as GetBalanceRpcRequest;
+
+    const result = await getBalance(validRequest, mockWallet, {}, mockTriggerHandler);
+
+    expect(result.response).toHaveLength(2);
+    expect((result.response as any)[0].token.id).toBe('00');
+    expect((result.response as any)[1].token.id).toBe('000003521effbc8efd7b746a118cdc7d41d7cc1bf9c5d1fa5de4f8453f14ba4f');
+    expect(mockWallet.getBalance).toHaveBeenCalledTimes(2);
+    expect(mockWallet.getBalance).toHaveBeenCalledWith('00');
+    expect(mockWallet.getBalance).toHaveBeenCalledWith('000003521effbc8efd7b746a118cdc7d41d7cc1bf9c5d1fa5de4f8453f14ba4f');
   });
 });

--- a/packages/hathor-rpc-handler/__tests__/rpcMethods/getBalance.test.ts
+++ b/packages/hathor-rpc-handler/__tests__/rpcMethods/getBalance.test.ts
@@ -6,9 +6,11 @@
  */
 
 import { HathorWallet } from '@hathor/wallet-lib';
-import { 
+import {
   RpcMethods,
   GetBalanceRpcRequest,
+  TriggerResponseTypes,
+  GetBalanceResponse,
 } from '../../src/types';
 import { getBalance } from '../../src/rpcMethods/getBalance';
 import { InvalidParamsError, NotImplementedError } from '../../src/errors';
@@ -39,7 +41,10 @@ describe('getBalance parameter validation', () => {
     }]),
   } as unknown as HathorWallet;
 
-  const mockTriggerHandler = jest.fn().mockResolvedValue(true);
+  const mockTriggerHandler = jest.fn().mockResolvedValue({
+    type: TriggerResponseTypes.GetBalanceConfirmationResponse,
+    data: true,
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -193,8 +198,8 @@ describe('getBalance parameter validation', () => {
     const result = await getBalance(validRequest, mockWallet, {}, mockTriggerHandler);
 
     expect(result.response).toHaveLength(2);
-    expect((result.response as any)[0].token.id).toBe('00');
-    expect((result.response as any)[1].token.id).toBe('000003521effbc8efd7b746a118cdc7d41d7cc1bf9c5d1fa5de4f8453f14ba4f');
+    expect((result as GetBalanceResponse).response[0].token.id).toBe('00');
+    expect((result as GetBalanceResponse).response[1].token.id).toBe('000003521effbc8efd7b746a118cdc7d41d7cc1bf9c5d1fa5de4f8453f14ba4f');
     expect(mockWallet.getBalance).toHaveBeenCalledTimes(2);
     expect(mockWallet.getBalance).toHaveBeenCalledWith('00');
     expect(mockWallet.getBalance).toHaveBeenCalledWith('000003521effbc8efd7b746a118cdc7d41d7cc1bf9c5d1fa5de4f8453f14ba4f');

--- a/packages/hathor-rpc-handler/src/rpcMethods/getBalance.ts
+++ b/packages/hathor-rpc-handler/src/rpcMethods/getBalance.ts
@@ -47,7 +47,7 @@ export async function getBalance(
   promptHandler: TriggerHandler,
 ) {
   const parseResult = getBalanceSchema.safeParse(rpcRequest.params);
-  
+
   if (!parseResult.success) {
     throw new InvalidParamsError(parseResult.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', '));
   }
@@ -60,9 +60,9 @@ export async function getBalance(
 
   validateNetwork(wallet, params.network);
 
-  const balances: GetBalanceObject[] = await Promise.all(
+  const balances: GetBalanceObject[] = (await Promise.all(
     params.tokens.map(token => wallet.getBalance(token)),
-  );
+  )).flat();
 
   const prompt: GetBalanceConfirmationPrompt = {
     type: TriggerTypes.GetBalanceConfirmationPrompt,

--- a/packages/hathor-rpc-handler/src/rpcMethods/getBalance.ts
+++ b/packages/hathor-rpc-handler/src/rpcMethods/getBalance.ts
@@ -16,6 +16,7 @@ import {
   RequestMetadata,
   RpcResponseTypes,
   RpcResponse,
+  GetBalanceConfirmationResponse,
 } from '../types';
 import { NotImplementedError, PromptRejectedError, InvalidParamsError } from '../errors';
 import { validateNetwork } from '../helpers';
@@ -70,9 +71,12 @@ export async function getBalance(
     data: balances
   };
 
-  const confirmed = await promptHandler(prompt, requestMetadata);
+  const confirmed = await promptHandler(
+    prompt,
+    requestMetadata
+  ) as GetBalanceConfirmationResponse;
 
-  if (!confirmed) {
+  if (!confirmed.data) {
     throw new PromptRejectedError();
   }
 

--- a/packages/hathor-rpc-handler/src/types/prompt.ts
+++ b/packages/hathor-rpc-handler/src/types/prompt.ts
@@ -45,6 +45,7 @@ export enum TriggerResponseTypes {
   SignOracleDataConfirmationResponse,
   SendTransactionConfirmationResponse,
   CreateNanoContractCreateTokenTxConfirmationResponse,
+  GetBalanceConfirmationResponse
 }
 
 export type Trigger =
@@ -209,7 +210,7 @@ export interface SendNanoContractTxConfirmationResponse {
     accepted: true;
     nc: NanoContractParams & {
       caller: string;
-    } 
+    }
   } | {
     accepted: false;
   }
@@ -233,6 +234,11 @@ export interface PinRequestResponse {
   } | {
     accepted: false;
   }
+}
+
+export interface GetBalanceConfirmationResponse {
+  type: TriggerResponseTypes.GetBalanceConfirmationResponse;
+  data: boolean;
 }
 
 export interface GetUtxosConfirmationResponse {
@@ -308,7 +314,8 @@ export type TriggerResponse =
   | CreateTokenConfirmationResponse
   | SignOracleDataConfirmationResponse
   | SendTransactionConfirmationResponse
-  | CreateNanoContractCreateTokenTxConfirmationResponse;
+  | CreateNanoContractCreateTokenTxConfirmationResponse
+  | GetBalanceConfirmationResponse;
 
 export type TriggerHandler = (prompt: Trigger, requestMetadata: RequestMetadata) => Promise<TriggerResponse | void>;
 


### PR DESCRIPTION
### Motivation

`wallet.getBalance('00');` returns an array with a single object containing the balance for the requested token, e.g.:

```
[
  {
    "token": {
      "id": "000003521effbc8efd7b746a118cdc7d41d7cc1bf9c5d1fa5de4f8453f14ba4f"
    },
    "balance": {
      "unlocked": "0",
      "locked": "0"
    },
    "transactions": 0,
    "lockExpires": null,
    "tokenAuthorities": {
      "unlocked": {
        "mint": "0",
        "melt": "0"
      },
      "locked": {
        "mint": "0",
        "melt": "0"
      }
    }
  }
]
```

We want to "flat" this array so we have a list of balances instead of a list of arrays of balances

### Acceptance Criteria

- We should flat the balances list
- We should fix the response from the get balances rpc to follow the same format as the other rpcs:
```
{
    type: TriggerResponseTypes.GetBalanceConfirmationResponse,
    data: true,
}
```

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
