### PR TITLE
fix: get address request confirmation should have a type for it

### DIFF
--- a/packages/hathor-rpc-handler/__tests__/rpcMethods/getAddress.test.ts
+++ b/packages/hathor-rpc-handler/__tests__/rpcMethods/getAddress.test.ts
@@ -22,7 +22,7 @@ describe('getAddress parameter validation', () => {
     getAddressAtIndex: jest.fn().mockResolvedValue('test-address'),
   } as unknown as HathorWallet;
 
-  const mockTriggerHandler = jest.fn().mockResolvedValue(true);
+  const mockTriggerHandler = jest.fn().mockResolvedValue({ data: true });
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/hathor-rpc-handler/src/rpcMethods/getAddress.ts
+++ b/packages/hathor-rpc-handler/src/rpcMethods/getAddress.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import type { HathorWallet } from '@hathor/wallet-lib';
 import {
   AddressRequestClientResponse,
+  AddressRequestConfirmationResponse,
   TriggerTypes,
   GetAddressRpcRequest,
   TriggerHandler,
@@ -106,9 +107,9 @@ export async function getAddress(
         data: {
           address,
         }
-      }, requestMetadata);
+      }, requestMetadata) as AddressRequestConfirmationResponse;
 
-      if (!confirmed) {
+      if (!confirmed.data) {
         throw new PromptRejectedError();
       }
     }

--- a/packages/hathor-rpc-handler/src/types/prompt.ts
+++ b/packages/hathor-rpc-handler/src/types/prompt.ts
@@ -37,6 +37,7 @@ export enum TriggerTypes {
 
 export enum TriggerResponseTypes {
   AddressRequestClientResponse,
+  AddressRequestConfirmationResponse,
   PinRequestResponse,
   GetUtxosConfirmationResponse,
   SignMessageWithAddressConfirmationResponse,
@@ -236,6 +237,11 @@ export interface PinRequestResponse {
   }
 }
 
+export interface AddressRequestConfirmationResponse {
+  type: TriggerResponseTypes.AddressRequestConfirmationResponse;
+  data: boolean;
+}
+
 export interface GetBalanceConfirmationResponse {
   type: TriggerResponseTypes.GetBalanceConfirmationResponse;
   data: boolean;
@@ -307,6 +313,7 @@ export interface CreateNanoContractCreateTokenTxConfirmationResponse {
 
 export type TriggerResponse =
   AddressRequestClientResponse
+  | AddressRequestConfirmationResponse
   | GetUtxosConfirmationResponse
   | PinRequestResponse
   | SignMessageWithAddressConfirmationResponse


### PR DESCRIPTION
### Motivation

After a previous refactor, the get request address confirmation prompt should have a type for its return.

### Acceptance Criteria

- Add return type for `GetRequestAddressConfirmation` prompt

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
