### PR TITLE
chore: bump wallet lib to 2.7.0

### DIFF
--- a/packages/hathor-rpc-handler/package.json
+++ b/packages/hathor-rpc-handler/package.json
@@ -30,7 +30,7 @@
     "typescript-eslint": "7.13.0"
   },
   "dependencies": {
-    "@hathor/wallet-lib": "2.5.1",
+    "@hathor/wallet-lib": "2.7.0",
     "zod": "3.23.8"
   }
 }

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@hathor/hathor-rpc-handler": "workspace:*",
-    "@hathor/wallet-lib": "2.6.1",
+    "@hathor/wallet-lib": "2.7.0",
     "@metamask/snaps-sdk": "9.2.0",
     "node-stdlib-browser": "1.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1531,7 +1531,7 @@ __metadata:
   resolution: "@hathor/hathor-rpc-handler@workspace:packages/hathor-rpc-handler"
   dependencies:
     "@eslint/js": "npm:9.4.0"
-    "@hathor/wallet-lib": "npm:2.5.1"
+    "@hathor/wallet-lib": "npm:2.7.0"
     "@types/eslint__js": "npm:8.42.3"
     "@types/jest": "npm:29.5.12"
     "@types/node": "npm:20.14.2"
@@ -1544,9 +1544,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@hathor/wallet-lib@npm:2.5.1":
-  version: 2.5.1
-  resolution: "@hathor/wallet-lib@npm:2.5.1"
+"@hathor/wallet-lib@npm:2.7.0":
+  version: 2.7.0
+  resolution: "@hathor/wallet-lib@npm:2.7.0"
   dependencies:
     axios: "npm:1.7.7"
     bitcore-lib: "npm:8.25.10"
@@ -1558,25 +1558,7 @@ __metadata:
     queue-microtask: "npm:1.2.3"
     ws: "npm:8.17.1"
     zod: "npm:3.23.8"
-  checksum: 10/6afb2123a29de80d09cfcbe14c69709a41cd36e1f4fdcbe5dcb74690057dbff482d434a904e734a0154ded4fb8e168eb443acba4d9b5815795d92f677f274b09
-  languageName: node
-  linkType: hard
-
-"@hathor/wallet-lib@npm:2.6.1":
-  version: 2.6.1
-  resolution: "@hathor/wallet-lib@npm:2.6.1"
-  dependencies:
-    axios: "npm:1.7.7"
-    bitcore-lib: "npm:8.25.10"
-    bitcore-mnemonic: "npm:8.25.10"
-    buffer: "npm:6.0.3"
-    crypto-js: "npm:4.2.0"
-    isomorphic-ws: "npm:5.0.0"
-    lodash: "npm:4.17.21"
-    queue-microtask: "npm:1.2.3"
-    ws: "npm:8.17.1"
-    zod: "npm:3.23.8"
-  checksum: 10/958415d6884d267fd3167285e99a30c69ec84efa3c7066d17784245cff237a5d19e8ba2abd57f2197d9b7b2b3b7ab4527145599e39dabdc393f52639cd0da690
+  checksum: 10/627867bb7874066b6332409e4f0abd465184a78e9aa83b62f045f779fedff4d1791b7d44e887e46efe2ef7735a3cff822647540651ee50539e5656b5f408acbd
   languageName: node
   linkType: hard
 
@@ -10715,7 +10697,7 @@ __metadata:
   resolution: "snap@workspace:packages/snap"
   dependencies:
     "@hathor/hathor-rpc-handler": "workspace:*"
-    "@hathor/wallet-lib": "npm:2.6.1"
+    "@hathor/wallet-lib": "npm:2.7.0"
     "@jest/globals": "npm:29.7.0"
     "@metamask/auto-changelog": "npm:3.4.4"
     "@metamask/eslint-config": "npm:12.2.0"


### PR DESCRIPTION
### Acceptance Criteria

- Bump wallet lib to v2.7.0 in `snap` and `hathor-rpc-handler` packages

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
