### PR TITLE
Skip Permission Prompt for First Address (Index 0) in htr_getAddress

### DIFF
--- a/packages/hathor-rpc-handler/src/rpcMethods/getAddress.ts
+++ b/packages/hathor-rpc-handler/src/rpcMethods/getAddress.ts
@@ -109,7 +109,7 @@ export async function getAddress(
 
     // We already confirmed with the user and he selected the address he wanted
     // to share. No need to double check
-    if (params.type !== 'client') {
+    if (params.type !== 'client' && addressInfo.index !== 0) {
       const confirmed = await promptHandler({
         ...rpcRequest,
         type: TriggerTypes.AddressRequestPrompt,


### PR DESCRIPTION
## Summary  
This PR improves the dApp user experience by enabling **automatic retrieval of the first wallet address (index 0)** without requiring a permission confirmation prompt.  
All other addresses continue to require explicit user approval, ensuring security is preserved.

## Problem  
Currently, `htr_getAddress` **always** prompts users for permission – even when requesting the first address (`index 0`).  
This creates unnecessary friction in onboarding flows, where developers often need to immediately display:  
- the user’s **primary address** (index 0),  
- auto-connect status, and  
- initial UI state.  

As a result, dApps face delays and extra confirmation steps for a very common use case.

## Solution  
This update modifies the `getAddress` method to:  
- **Skip the permission prompt only for `index 0`**, allowing seamless retrieval of the primary address.  
- **Maintain security for all other address indices**, which still require explicit user confirmation.  

This strikes a balance between developer convenience, smoother onboarding UX, and user security.
