### PR TITLE
chore: bumped snap and snap-utils to v0.1.1

### DIFF
--- a/packages/snap-utils/package.json
+++ b/packages/snap-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "snap-utils",
   "packageManager": "yarn@4.2.2",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "files": [
     "dist"
   ],

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "snap",
   "packageManager": "yarn@4.2.2",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "license": "",
   "main": "./dist/bundle.js",


### PR DESCRIPTION
### Acceptance Criteria

- Bump both the snap and snap-utils to v0.1.1

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
