### PR TITLE
feat: get blueprint id from the util method

### DIFF
--- a/packages/hathor-rpc-handler/__tests__/rpcMethods/sendNanoContractTx.test.ts
+++ b/packages/hathor-rpc-handler/__tests__/rpcMethods/sendNanoContractTx.test.ts
@@ -509,6 +509,29 @@ describe('sendNanoContractTx parameter validation', () => {
   });
 
   it('should accept valid parameters with nc_id', async () => {
+    const promptHandler = jest.fn()
+      .mockResolvedValueOnce({
+        type: TriggerResponseTypes.SendNanoContractTxConfirmationResponse,
+        data: {
+          accepted: true,
+          nc: {
+            caller: 'test-caller',
+            blueprintId: 'test-blueprint',
+            ncId: null,
+            actions: [] as NanoContractAction[],
+            args: [] as unknown[],
+            method: 'test-method',
+            pushTx: true,
+          },
+        }
+      })
+      .mockResolvedValueOnce({
+        type: TriggerResponseTypes.PinRequestResponse,
+        data: {
+          accepted: true,
+          pinCode: '1234',
+        }
+      });
     const validActions = [
       {
         type: 'deposit',
@@ -523,7 +546,7 @@ describe('sendNanoContractTx parameter validation', () => {
       params: {
         network: 'mainnet',
         method: 'test-method',
-        blueprint_id: '',
+        blueprint_id: '',  // no blueprint id in the parameters
         nc_id: 'test-nc-id',
         actions: validActions as unknown as NanoContractAction[],
         args: [] as unknown[],
@@ -531,9 +554,22 @@ describe('sendNanoContractTx parameter validation', () => {
       },
     } as SendNanoContractRpcRequest;
 
-    await expect(
-      sendNanoContractTx(validRequest, mockWallet, {}, mockTriggerHandler)
-    ).resolves.toBeDefined();
+    await sendNanoContractTx(validRequest, mockWallet, {}, promptHandler);
+    expect(promptHandler).toHaveBeenCalledWith({
+      ...validRequest,
+      type: TriggerTypes.SendNanoContractTxConfirmationPrompt,
+      data: {
+        actions: expect.any(Array),
+        args: expect.any(Array),
+        parsedArgs: expect.any(Array),
+        blueprintId: 'test-blueprint',  // make sure we added the blueprint id in the data object
+        method: expect.any(String),
+        ncId: expect.any(String),
+        pushTx: expect.any(Boolean),
+      }
+    }, {});
+
+    expect(nanoUtils.getBlueprintId).toHaveBeenCalled();
   });
 
   it('should use default push_tx value when not provided', async () => {

--- a/packages/hathor-rpc-handler/__tests__/rpcMethods/sendNanoContractTx.test.ts
+++ b/packages/hathor-rpc-handler/__tests__/rpcMethods/sendNanoContractTx.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { HathorWallet, nanoUtils } from '@hathor/wallet-lib';
+import { HathorWallet, nanoUtils, ncApi } from '@hathor/wallet-lib';
 import { NanoContractAction } from '@hathor/wallet-lib/lib/nano_contracts/types';
 import { sendNanoContractTx, NanoContractActionWithStringAmount } from '../../src/rpcMethods/sendNanoContractTx';
 import { TriggerTypes, RpcMethods, SendNanoContractRpcRequest, TriggerResponseTypes, RpcResponseTypes } from '../../src/types';
@@ -13,6 +13,14 @@ import { SendNanoContractTxError, InvalidParamsError } from '../../src/errors';
 
 
 jest.spyOn(nanoUtils, 'validateAndParseBlueprintMethodArgs').mockResolvedValue([]);
+jest.spyOn(nanoUtils, 'getBlueprintId').mockResolvedValue('test-blueprint');
+jest.spyOn(ncApi, 'getBlueprintInformation').mockResolvedValue({
+  id: 'mock-blueprint-id',
+  name: 'mock-blueprint',
+  attributes: new Map(),
+  public_methods: new Map(),
+  private_methods: new Map(),
+});
 
 describe('sendNanoContractTx', () => {
   let rpcRequest: SendNanoContractRpcRequest;

--- a/packages/hathor-rpc-handler/src/rpcMethods/sendNanoContractTx.ts
+++ b/packages/hathor-rpc-handler/src/rpcMethods/sendNanoContractTx.ts
@@ -22,7 +22,7 @@ import {
   SendNanoContractTxLoadingFinishedTrigger,
 } from '../types';
 import { PromptRejectedError, SendNanoContractTxError, InvalidParamsError } from '../errors';
-import { INanoContractActionSchema, NanoContractAction, nanoUtils, Network, config } from '@hathor/wallet-lib';
+import { INanoContractActionSchema, NanoContractAction, ncApi, nanoUtils, Network, config } from '@hathor/wallet-lib';
 
 export type NanoContractActionWithStringAmount = Omit<NanoContractAction, 'amount'> & {
   amount: string,
@@ -76,24 +76,27 @@ export async function sendNanoContractTx(
     };
 
     let blueprintId = params.blueprintId;
-    if (!blueprintId) {
-      let response;
+    if (blueprintId) {
+      // Check if the user sent a valid blueprint id
       try {
-        response = await wallet.getFullTxById(params.ncId!);
+        await ncApi.getBlueprintInformation(blueprintId);
+      } catch (e) {
+        // Invalid blueprint id
+        throw new SendNanoContractTxError(
+          `Invalid blueprint ID ${blueprintId}`
+        );
+      }
+    }
+
+    if (!blueprintId) {
+      try {
+        blueprintId = await nanoUtils.getBlueprintId(params.ncId!, wallet);
       } catch {
-        // Error getting nano contract transaction data from the full node
+        // Error getting blueprint ID
         throw new SendNanoContractTxError(
-          `Error getting nano contract transaction data with id ${params.ncId} from the full node`
+          `Error getting blueprint id with nc id ${params.ncId} from the full node`
         );
       }
-
-      if (!response.tx.nc_id) {
-        throw new SendNanoContractTxError(
-          `Transaction with id ${params.ncId} is not a nano contract transaction.`
-        );
-      }
-
-      blueprintId = response.tx.nc_blueprint_id!;
     }
 
     config.setServerUrl(wallet.getServerUrl());
@@ -106,7 +109,7 @@ export async function sendNanoContractTx(
       ...rpcRequest,
       type: TriggerTypes.SendNanoContractTxConfirmationPrompt,
       data: {
-        blueprintId: params.blueprintId,
+        blueprintId,
         ncId: params.ncId,
         actions: params.actions,
         method: params.method,


### PR DESCRIPTION
### Motivation

Contracts created by contracts can't be fetched using `getFullTxById`.

### Acceptance Criteria

- Use nano utils method to fetch blueprint ID.
- Validate if blueprintId user param is valid
- Pass fetched blueprint ID to the data object, so it can be used by the wallets.

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
