### PR TITLE
feat: add new rpc method to get wallet information and show warning for the user in post install page

### DIFF
--- a/packages/hathor-rpc-handler/__tests__/rpcMethods/getWalletInformation.test.ts
+++ b/packages/hathor-rpc-handler/__tests__/rpcMethods/getWalletInformation.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { HathorWallet } from '@hathor/wallet-lib';
+import {
+  RpcMethods,
+  GetWalletInformationRpcRequest,
+  RpcResponseTypes,
+} from '../../src/types';
+import { getWalletInformation } from '../../src/rpcMethods/getWalletInformation';
+import { InvalidParamsError } from '../../src/errors';
+
+describe('getWalletInformation parameter validation', () => {
+  const mockWallet = {
+    getNetwork: jest.fn().mockReturnValue('testnet'),
+    getAddressAtIndex: jest.fn().mockResolvedValue('test-address'),
+  } as unknown as HathorWallet;
+
+  const mockTriggerHandler = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should reject when method is missing', async () => {
+    const invalidRequest = {
+      // method is missing
+    } as GetWalletInformationRpcRequest;
+
+    await expect(
+      getWalletInformation(invalidRequest, mockWallet, {}, mockTriggerHandler)
+    ).rejects.toThrow(InvalidParamsError);
+  });
+
+  it('should reject when method is invalid', async () => {
+    const invalidRequest = {
+      method: 'invalid_method',
+    } as unknown as GetWalletInformationRpcRequest;
+
+    await expect(
+      getWalletInformation(invalidRequest, mockWallet, {}, mockTriggerHandler)
+    ).rejects.toThrow(InvalidParamsError);
+  });
+
+  it('should accept valid request and return wallet information', async () => {
+    const validRequest = {
+      method: RpcMethods.GetWalletInformation,
+    } as GetWalletInformationRpcRequest;
+
+    const result = await getWalletInformation(validRequest, mockWallet, {}, mockTriggerHandler);
+
+    expect(result).toBeDefined();
+    expect(result.type).toBe(RpcResponseTypes.GetWalletInformationResponse);
+    expect(result.response).toEqual({
+      network: 'testnet',
+      address0: 'test-address',
+    });
+    expect(mockWallet.getNetwork).toHaveBeenCalled();
+    expect(mockWallet.getAddressAtIndex).toHaveBeenCalledWith(0);
+  });
+
+  it('should work with different network', async () => {
+    const mockMainnetWallet = {
+      getNetwork: jest.fn().mockReturnValue('mainnet'),
+      getAddressAtIndex: jest.fn().mockResolvedValue('HTestAddress123'),
+    } as unknown as HathorWallet;
+
+    const validRequest = {
+      method: RpcMethods.GetWalletInformation,
+    } as GetWalletInformationRpcRequest;
+
+    const result = await getWalletInformation(validRequest, mockMainnetWallet, {}, mockTriggerHandler);
+
+    expect(result.response).toEqual({
+      network: 'mainnet',
+      address0: 'HTestAddress123',
+    });
+  });
+});

--- a/packages/hathor-rpc-handler/src/rpcHandler/index.ts
+++ b/packages/hathor-rpc-handler/src/rpcHandler/index.ts
@@ -23,6 +23,7 @@ import {
   SendTransactionRpcRequest,
   CreateNanoContractCreateTokenTxRpcRequest,
   ChangeNetworkRpcRequest,
+  GetWalletInformationRpcRequest,
 } from '../types';
 import {
   getAddress,
@@ -36,6 +37,7 @@ import {
   sendTransaction,
   createNanoContractCreateTokenTx,
   changeNetwork,
+  getWalletInformation,
 } from '../rpcMethods';
 import { InvalidRpcMethod } from '../errors';
 
@@ -108,6 +110,12 @@ export const handleRpcRequest = async (
     );
     case RpcMethods.ChangeNetwork: return changeNetwork(
       request as ChangeNetworkRpcRequest,
+      wallet,
+      requestMetadata,
+      promptHandler,
+    );
+    case RpcMethods.GetWalletInformation: return getWalletInformation(
+      request as GetWalletInformationRpcRequest,
       wallet,
       requestMetadata,
       promptHandler,

--- a/packages/hathor-rpc-handler/src/rpcMethods/getWalletInformation.ts
+++ b/packages/hathor-rpc-handler/src/rpcMethods/getWalletInformation.ts
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { z } from 'zod';
+import type { IHathorWallet } from '@hathor/wallet-lib';
+import {
+  GetWalletInformationRpcRequest,
+  RequestMetadata,
+  RpcResponse,
+  RpcResponseTypes,
+  TriggerHandler,
+  RpcMethods,
+} from '../types';
+import { InvalidParamsError } from '../errors';
+
+const getWalletInformationSchema = z.object({
+  method: z.literal(RpcMethods.GetWalletInformation),
+});
+
+/**
+ * Handles the 'get_wallet_information' RPC request by retrieving the network information
+ * and the address at index 0 from the wallet.
+ *
+ * @param rpcRequest - The RPC request object containing the method.
+ * @param wallet - The Hathor wallet instance used to get the wallet information.
+ * @param _requestMetadata - (unused) Metadata related to the dApp that sent the RPC
+ * @param _promptHandler - (unused) The function to handle prompts for user confirmation.
+ *
+ * @returns An object containing the network name and address at index 0.
+ *
+ * @throws {InvalidParamsError} - If the request parameters are invalid.
+ */
+export async function getWalletInformation(
+  rpcRequest: GetWalletInformationRpcRequest,
+  wallet: IHathorWallet,
+  _requestMetadata: RequestMetadata,
+  _promptHandler: TriggerHandler,
+) {
+  const parseResult = getWalletInformationSchema.safeParse(rpcRequest);
+
+  if (!parseResult.success) {
+    throw new InvalidParamsError(parseResult.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', '));
+  }
+
+  const network: string = wallet.getNetwork();
+  const address0 = await wallet.getAddressAtIndex(0);
+
+  const result = {
+    network,
+    address0,
+  };
+
+  return {
+    type: RpcResponseTypes.GetWalletInformationResponse,
+    response: result,
+  } as RpcResponse;
+}

--- a/packages/hathor-rpc-handler/src/rpcMethods/index.ts
+++ b/packages/hathor-rpc-handler/src/rpcMethods/index.ts
@@ -9,3 +9,4 @@ export * from './createToken';
 export * from './sendTransaction';
 export * from './createNanoContractCreateTokenTx';
 export * from './changeNetwork';
+export * from './getWalletInformation';

--- a/packages/hathor-rpc-handler/src/types/rpcRequest.ts
+++ b/packages/hathor-rpc-handler/src/types/rpcRequest.ts
@@ -21,6 +21,7 @@ export enum RpcMethods {
   SendTransaction = 'htr_sendTransaction',
   CreateNanoContractCreateTokenTx = 'htr_createNanoContractCreateTokenTx',
   ChangeNetwork = 'htr_changeNetwork',
+  GetWalletInformation = 'htr_getWalletInformation',
 }
 
 export interface CreateTokenRpcRequest {
@@ -156,6 +157,10 @@ export interface ChangeNetworkRpcRequest {
   }
 }
 
+export interface GetWalletInformationRpcRequest {
+  method: RpcMethods.GetWalletInformation,
+}
+
 export interface GenericRpcRequest {
   method: string;
   params?: unknown | null;
@@ -171,5 +176,6 @@ export type RpcRequest = GetAddressRpcRequest
   | SignOracleDataRpcRequest
   | SendTransactionRpcRequest
   | CreateNanoContractCreateTokenTxRpcRequest
-  | ChangeNetworkRpcRequest;
+  | ChangeNetworkRpcRequest
+  | GetWalletInformationRpcRequest;
 

--- a/packages/hathor-rpc-handler/src/types/rpcResponse.ts
+++ b/packages/hathor-rpc-handler/src/types/rpcResponse.ts
@@ -22,6 +22,7 @@ export enum RpcResponseTypes {
   SendTransactionResponse,
   CreateNanoContractCreateTokenTxResponse,
   ChangeNetworkResponse,
+  GetWalletInformationResponse,
 }
 
 export interface BaseRpcResponse {
@@ -96,6 +97,14 @@ export interface ChangeNetworkResponse extends BaseRpcResponse {
   }
 }
 
+export interface GetWalletInformationResponse extends BaseRpcResponse {
+  type: RpcResponseTypes.GetWalletInformationResponse;
+  response: {
+    network: string;
+    address0: string;
+  }
+}
+
 export type RpcResponse = GetAddressResponse
   | SendNanoContractTxResponse
   | SignWithAddressResponse
@@ -106,4 +115,5 @@ export type RpcResponse = GetAddressResponse
   | GetUtxosResponse
   | SendTransactionResponse
   | CreateNanoContractCreateTokenTxResponse
-  | ChangeNetworkResponse;
+  | ChangeNetworkResponse
+  | GetWalletInformationResponse;

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -3,7 +3,7 @@
   "description": "Hathor Network Snap integration",
   "proposedName": "Hathor Wallet",
   "source": {
-    "shasum": "yAUQ+DAfX+0AgqZGrDSyi9sonZNa2qcc/+ykDvU2SMY=",
+    "shasum": "9KhKpLhF85T5MGeb2seVTxoIp9qjS49/2HIJP2fyHXk=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -15,6 +15,7 @@
   },
   "initialPermissions": {
     "snap_dialog": {},
+    "endowment:lifecycle-hooks": {},
     "snap_manageState": {},
     "endowment:rpc": {
       "dapps": true,

--- a/packages/snap/src/constants.ts
+++ b/packages/snap/src/constants.ts
@@ -13,6 +13,7 @@ export enum REQUEST_METHODS {
 
 export enum DIALOG_TYPES {
   CONFIRMATION = 'confirmation',
+  ALERT = 'alert',
 }
 
 const MAINNET_URLS = {

--- a/packages/snap/src/dialogs/install.jsx
+++ b/packages/snap/src/dialogs/install.jsx
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { REQUEST_METHODS, DIALOG_TYPES } from '../constants';
+import { Box, Container, Link, Heading, Text } from '@metamask/snaps-sdk/jsx';
+
+export const installPage = async () => (
+  await snap.request({
+    method: REQUEST_METHODS.DIALOG,
+    params: {
+      type: DIALOG_TYPES.ALERT,
+      content: (
+        <Container backgroundColor='alternative'>
+          <Box>
+            <Heading>Installation successful</Heading>
+            <Text>
+              You can access the full documentation on the <Link href="https://docs.hathor.network/explanations/features/metamask-snap">Hathor docs</Link>
+            </Text>
+            <Text>
+              The dApp you are connecting to will have access to your first address and the network you are connected to
+            </Text>
+          </Box>
+        </Container>
+      ),
+    },
+  })
+)

--- a/packages/snap/src/index.tsx
+++ b/packages/snap/src/index.tsx
@@ -5,17 +5,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { OnRpcRequestHandler } from '@metamask/snaps-sdk';
-import { Box, Text, Bold, Heading, Link } from '@metamask/snaps-sdk/jsx';
+import type { OnRpcRequestHandler, OnInstallHandler } from '@metamask/snaps-sdk';
 import { getHathorWallet } from './utils/wallet';
 import { getNetworkData } from './utils/network';
 import { promptHandler } from './utils/prompt';
-import { homePage } from './dialogs/home';
 import { installPage } from './dialogs/install';
-import { balanceHandler } from './methods/balance';
-import { addressHandler } from './methods/address';
 import { handleRpcRequest } from '@hathor/hathor-rpc-handler';
 import { bigIntUtils } from '@hathor/wallet-lib';
+
+/**
+ * Handle installation of the snap. This handler is called when the snap is installed
+ *
+ * @returns The JSON-RPC response.
+ */
+export const onInstall: OnInstallHandler = async () => {
+  return installPage();
+};
 
 /**
  * Handle incoming JSON-RPC requests, sent through `wallet_invokeSnap`.


### PR DESCRIPTION
### Motivation

It's important for dApps to know the connected network and first address of the wallet. We decided to create this rpc method that doesn't need approval to share this information and show a warning of it to the user after the snap is installed.

### Acceptance Criteria

- Create rpc method to get wallet information (network and address0 for now)
- Create post install page with docs information and warning about dapps being able to get network and address0.

<img width="389" height="609" alt="image" src="https://github.com/user-attachments/assets/6aef74a8-716d-4a70-8b91-86858803fd20" />

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
