### PR TITLE
feat(snap): initialize wallet on network change

### DIFF
--- a/packages/snap/src/utils/network.ts
+++ b/packages/snap/src/utils/network.ts
@@ -7,6 +7,7 @@
 
 import { config } from '@hathor/wallet-lib';
 import { REQUEST_METHODS, DEFAULT_NETWORK, NETWORK_MAP } from '../constants';
+import { initializeWalletOnService } from './wallet';
 
 /*
  * Get persisted network data or the default from constants
@@ -40,6 +41,7 @@ export const setNetwork = async (network: string) => {
   });
 
   await configNetwork();
+  await initializeWalletOnService();
 }
 
 /*


### PR DESCRIPTION
### Acceptance Criteria

- We should call the start wallet API when changing network without waiting for it to be ready

### Checklist
- [X] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [X] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
