### PR TITLE
feat: add rpc request origin restrictions for get xpub request

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -3,7 +3,7 @@
   "description": "Hathor Network Snap integration",
   "proposedName": "Hathor Wallet",
   "source": {
-    "shasum": "9j6opOXoJBG0aZv1ZsDnlCpUZ55XZbUVWBABoFvJYIQ=",
+    "shasum": "fTsF2CUse8shPettQH1w7vfmJvW6ygZ6qZjWuGFGiKU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/constants.ts
+++ b/packages/snap/src/constants.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { RpcMethods } from '@hathor/hathor-rpc-handler';
+
 export enum REQUEST_METHODS {
   MANAGE_STATE = 'snap_manageState',
   GET_BIP32_ENTROPY = 'snap_getBip32Entropy',
@@ -55,3 +57,13 @@ export const NETWORK_MAP = {
 export const DEFAULT_NETWORK = 'mainnet';
 
 export const DEFAULT_PIN_CODE = '123';
+
+/*
+ * List of allowed dApps that can request each RPC request.
+ * If the RPC method is not in the list, any dApp can request it.
+ */
+export const RPC_RESTRICTIONS = {
+  [RpcMethods.GetXpub]: [
+    'https://wallet.hathor.network'
+  ],
+};

--- a/packages/snap/src/utils/helpers.ts
+++ b/packages/snap/src/utils/helpers.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { RPC_RESTRICTIONS } from '../constants';
+
+/*
+ * Check if the method requested is allowed for the origin requesting
+ */
+export const isRequestAllowed = (method: string, origin: string): boolean => {
+  if (method in RPC_RESTRICTIONS) {
+    return RPC_RESTRICTIONS[method].includes(origin);
+  }
+
+  return true;
+}


### PR DESCRIPTION
### Motivation

We shouldn't allow any dApp to request user xpub. We must restrict this RPC request only to our web wallet.

### Acceptance Criteria

- Add method to restrict access to some rpc requests depending on the origin.
- Allow only our web wallet to access get xpub rpc request.

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
