### PR TITLE
feat: add optional push_tx param to sendTransaction RPC

### DIFF
--- a/packages/hathor-rpc-handler/src/types/rpcRequest.ts
+++ b/packages/hathor-rpc-handler/src/types/rpcRequest.ts
@@ -127,6 +127,7 @@ export interface SendTransactionRpcRequest {
       index: number;
     }>;
     changeAddress?: string;
+    push_tx: boolean;
   }
 }
 

--- a/packages/hathor-rpc-handler/src/types/rpcResponse.ts
+++ b/packages/hathor-rpc-handler/src/types/rpcResponse.ts
@@ -83,7 +83,7 @@ export interface GetUtxosResponse extends BaseRpcResponse {
 
 export interface SendTransactionResponse extends BaseRpcResponse {
   type: RpcResponseTypes.SendTransactionResponse;
-  response: Transaction;
+  response: Transaction | string;
 }
 
 export interface CreateNanoContractCreateTokenTxResponse extends BaseRpcResponse {


### PR DESCRIPTION
We probably need to update the wallet modal as well, to detail it's not pushing the transaction. However, I believe SendNanoContractTxModal also does not detail it and also has the `push_tx` param.

<img width="497" height="652" alt="image" src="https://github.com/user-attachments/assets/56fb7f95-33ef-4195-bbca-8dd486e3bffe" />

