### PR TITLE
feat(web-wallet): add easy token import feature

### DIFF
--- a/packages/web-wallet/src/App.tsx
+++ b/packages/web-wallet/src/App.tsx
@@ -14,6 +14,7 @@ import CreateTokenDialog from './components/CreateTokenDialog'
 import { Loader2 } from 'lucide-react'
 import htrLogoBlack from './assets/htr_logo_black.svg'
 import AddressModeDialog from './components/AddressModeDialog'
+import ImportTokensDialog from './components/ImportTokensDialog'
 
 // Route wrappers that connect URL params to dialog props
 function SendDialogRoute() {
@@ -53,6 +54,11 @@ function CreateTokenDialogRoute() {
 function AddressModeDialogRoute() {
   const navigate = useNavigate()
   return <AddressModeDialog isOpen={true} onClose={() => navigate('/')} />
+}
+
+function ImportTokensDialogRoute() {
+  const navigate = useNavigate()
+  return <ImportTokensDialog isOpen={true} onClose={() => navigate('/')} />
 }
 
 // Component that gates the wallet based on feature toggle
@@ -98,6 +104,7 @@ function FeatureGatedWallet() {
             <Route path="register-token" element={<RegisterTokenDialogRoute />} />
             <Route path="create-token" element={<CreateTokenDialogRoute />} />
             <Route path="address-mode" element={<AddressModeDialogRoute />} />
+            <Route path="import-tokens" element={<ImportTokensDialogRoute />} />
           </Route>
         </Routes>
         <Toaster />

--- a/packages/web-wallet/src/components/Header.tsx
+++ b/packages/web-wallet/src/components/Header.tsx
@@ -13,10 +13,9 @@ interface HeaderProps {
   onCreateTokenClick?: () => void;
   onAddressModeClick?: () => void;
   onImportTokensClick?: () => void;
-  hasDiscoveredTokens?: boolean;
 }
 
-const Header: React.FC<HeaderProps> = ({ onRegisterTokenClick, onCreateTokenClick, onAddressModeClick, onImportTokensClick, hasDiscoveredTokens }) => {
+const Header: React.FC<HeaderProps> = ({ onRegisterTokenClick, onCreateTokenClick, onAddressModeClick, onImportTokensClick }) => {
   const { firstAddress, network, disconnectWallet } = useWallet();
   const [isNetworkDialogOpen, setIsNetworkDialogOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -86,17 +85,6 @@ const Header: React.FC<HeaderProps> = ({ onRegisterTokenClick, onCreateTokenClic
   // Shared menu items to avoid duplication between desktop and mobile
   const MenuItems = ({ className = '' }: { className?: string }) => (
     <>
-      {hasDiscoveredTokens && (
-        <button
-          onClick={() => {
-            setIsMenuOpen(false);
-            onImportTokensClick?.();
-          }}
-          className={className || "w-full px-4 py-3 text-left text-sm text-white hover:bg-[#24292F] transition-colors"}
-        >
-          Import Tokens
-        </button>
-      )}
       <button
         onClick={() => {
           setIsMenuOpen(false);
@@ -114,6 +102,15 @@ const Header: React.FC<HeaderProps> = ({ onRegisterTokenClick, onCreateTokenClic
         className={className || "w-full px-4 py-3 text-left text-sm text-white hover:bg-[#24292F] transition-colors"}
       >
         Register Tokens
+      </button>
+      <button
+        onClick={() => {
+          setIsMenuOpen(false);
+          onImportTokensClick?.();
+        }}
+        className={className || "w-full px-4 py-3 text-left text-sm text-white hover:bg-[#24292F] transition-colors"}
+      >
+        Import Tokens
       </button>
       <button
         onClick={() => {

--- a/packages/web-wallet/src/components/Header.tsx
+++ b/packages/web-wallet/src/components/Header.tsx
@@ -12,9 +12,11 @@ interface HeaderProps {
   onRegisterTokenClick?: () => void;
   onCreateTokenClick?: () => void;
   onAddressModeClick?: () => void;
+  onImportTokensClick?: () => void;
+  hasDiscoveredTokens?: boolean;
 }
 
-const Header: React.FC<HeaderProps> = ({ onRegisterTokenClick, onCreateTokenClick, onAddressModeClick }) => {
+const Header: React.FC<HeaderProps> = ({ onRegisterTokenClick, onCreateTokenClick, onAddressModeClick, onImportTokensClick, hasDiscoveredTokens }) => {
   const { firstAddress, network, disconnectWallet } = useWallet();
   const [isNetworkDialogOpen, setIsNetworkDialogOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -84,6 +86,17 @@ const Header: React.FC<HeaderProps> = ({ onRegisterTokenClick, onCreateTokenClic
   // Shared menu items to avoid duplication between desktop and mobile
   const MenuItems = ({ className = '' }: { className?: string }) => (
     <>
+      {hasDiscoveredTokens && (
+        <button
+          onClick={() => {
+            setIsMenuOpen(false);
+            onImportTokensClick?.();
+          }}
+          className={className || "w-full px-4 py-3 text-left text-sm text-white hover:bg-[#24292F] transition-colors"}
+        >
+          Import Tokens
+        </button>
+      )}
       <button
         onClick={() => {
           setIsMenuOpen(false);

--- a/packages/web-wallet/src/components/ImportTokensDialog.tsx
+++ b/packages/web-wallet/src/components/ImportTokensDialog.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 import { X, Loader2, ExternalLink, AlertCircle, CheckCircle } from 'lucide-react';
+import { useOutletContext } from 'react-router-dom';
 import { useWallet } from '../contexts/WalletContext';
 import { tokensUtils } from '@hathor/wallet-lib';
 import { truncateString } from '../utils/hathor';
 import { HATHOR_EXPLORER_URLS, NETWORKS } from '../constants';
 import { tokenDiscoveryService, type DiscoveredToken } from '../services/TokenDiscoveryService';
-import { useTokenDiscovery } from '../hooks/useTokenDiscovery';
 
 const BATCH_SIZE = 2;
 const BATCH_INTERVAL_MS = 500;
@@ -63,8 +63,11 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
   isOpen,
   onClose,
 }) => {
-  const { registerTokensBatch, network, isConnected } = useWallet();
-  const { discoveredTokenUids, refreshDiscovery } = useTokenDiscovery({ isConnected, network });
+  const { registerTokensBatch, network } = useWallet();
+  const { discoveredTokenUids, refreshDiscovery } = useOutletContext<{
+    discoveredTokenUids: string[];
+    refreshDiscovery: () => Promise<void>;
+  }>();
 
   // Token details loaded lazily, keyed by UID
   const [tokenDetails, setTokenDetails] = useState<Map<string, DiscoveredToken>>(new Map());
@@ -238,12 +241,13 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
 
     setIsImporting(false);
 
+    // Always re-run discovery so the banner updates (even on partial success)
+    refreshDiscovery();
+
     if (errors.length > 0) {
       setImportError(`Some tokens failed: ${errors.join(', ')}`);
     } else {
       setImportSuccess(true);
-      // Re-run discovery so the banner disappears
-      refreshDiscovery();
       setTimeout(() => handleClose(), 1500);
     }
   };

--- a/packages/web-wallet/src/components/ImportTokensDialog.tsx
+++ b/packages/web-wallet/src/components/ImportTokensDialog.tsx
@@ -79,19 +79,24 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
     ? HATHOR_EXPLORER_URLS.MAINNET
     : HATHOR_EXPLORER_URLS.TESTNET;
 
-  // Lazy load token details
+  // Ref to track which UIDs have been requested, avoiding duplicate fetches
+  // without depending on tokenDetails state (which would destabilize the callback)
+  const requestedRef = useRef(new Set<string>());
+
   const fetchDetail = useCallback(async (uid: string) => {
-    if (tokenDetails.has(uid)) return;
+    if (requestedRef.current.has(uid)) return;
+    requestedRef.current.add(uid);
 
     const detail = await tokenDiscoveryService.fetchTokenDetails(uid);
     if (detail) {
       setTokenDetails(prev => {
+        if (prev.has(uid)) return prev;
         const next = new Map(prev);
         next.set(uid, detail);
         return next;
       });
     }
-  }, [tokenDetails]);
+  }, []);
 
   const { enqueue, clear } = useThrottledQueue(fetchDetail);
 
@@ -114,7 +119,7 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
         for (const entry of entries) {
           if (entry.isIntersecting) {
             const uid = (entry.target as HTMLElement).dataset.tokenUid;
-            if (uid && !tokenDetails.has(uid)) {
+            if (uid && !requestedRef.current.has(uid)) {
               visibleUids.push(uid);
             }
           }
@@ -128,7 +133,7 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
     if (container) {
       container.querySelectorAll('[data-token-uid]').forEach(row => observerRef.current?.observe(row));
     }
-  }, [enqueue, tokenDetails]);
+  }, [enqueue]);
 
   useEffect(() => {
     if (!isOpen || discoveredTokenUids.length === 0) return;

--- a/packages/web-wallet/src/components/ImportTokensDialog.tsx
+++ b/packages/web-wallet/src/components/ImportTokensDialog.tsx
@@ -321,8 +321,19 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
 
               {/* Empty state */}
               {discoveredTokenUids.length === 0 && (
-                <div className="text-center py-8">
-                  <p className="text-sm text-muted-foreground">No new tokens found on your wallet.</p>
+                <div className="text-center py-6 space-y-3">
+                  <p className="text-sm font-bold text-white">No tokens available to import</p>
+                  <p className="text-xs text-muted-foreground">
+                    We didn't find any unregistered tokens linked to your wallet.
+                    <br />
+                    You can register a new one manually.
+                  </p>
+                  <button
+                    onClick={() => { handleClose(); navigate('/register-token'); }}
+                    className="px-6 py-2.5 bg-[#0D1117] border border-border hover:bg-[#161B22] text-white rounded-lg transition-colors font-medium"
+                  >
+                    Register a token
+                  </button>
                 </div>
               )}
 

--- a/packages/web-wallet/src/components/ImportTokensDialog.tsx
+++ b/packages/web-wallet/src/components/ImportTokensDialog.tsx
@@ -215,6 +215,16 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
       try {
         const result = await registerTokensBatch(configStrings);
         errors.push(...result.errors.map(e => e.error));
+
+        // Remove successfully imported tokens from selection
+        if (result.registered.length > 0) {
+          const importedUids = new Set(result.registered.map(t => t.uid));
+          setSelectedTokens(prev => {
+            const next = new Set(prev);
+            importedUids.forEach(uid => next.delete(uid));
+            return next;
+          });
+        }
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'Unknown error';
         errors.push(`Import failed: ${msg}`);
@@ -231,6 +241,7 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
 
     if (errors.length > 0) {
       setImportError(`Some tokens failed: ${errors.join(', ')}`);
+      setStep('select');
     } else {
       setStep('success');
     }
@@ -301,7 +312,7 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
       className="fixed inset-0 bg-black/50 flex items-start md:items-center justify-center z-50 overflow-y-auto p-4 md:p-0"
       onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
     >
-      <div role="dialog" aria-labelledby="import-tokens-title" className="bg-[#191C21] border border-[#24292F] rounded-2xl w-full max-w-md my-4 md:my-0 md:mx-4">
+      <div role="dialog" aria-modal="true" aria-labelledby="import-tokens-title" className="bg-[#191C21] border border-[#24292F] rounded-2xl w-full max-w-md my-4 md:my-0 md:mx-4">
         {/* Header */}
         <div className="relative flex items-center justify-center p-6 border-b border-[#24292F]">
           <h2 id="import-tokens-title" className="text-base font-bold text-primary-400">

--- a/packages/web-wallet/src/components/ImportTokensDialog.tsx
+++ b/packages/web-wallet/src/components/ImportTokensDialog.tsx
@@ -273,11 +273,12 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
       className="fixed inset-0 bg-black/50 flex items-start md:items-center justify-center z-50 overflow-y-auto p-4 md:p-0"
       onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
     >
-      <div className="bg-[#191C21] border border-[#24292F] rounded-2xl w-full max-w-md my-4 md:my-0 md:mx-4">
+      <div role="dialog" aria-labelledby="import-tokens-title" className="bg-[#191C21] border border-[#24292F] rounded-2xl w-full max-w-md my-4 md:my-0 md:mx-4">
         {/* Header */}
         <div className="relative flex items-center justify-center p-6 border-b border-[#24292F]">
-          <h2 className="text-base font-bold text-primary-400">Import Tokens</h2>
+          <h2 id="import-tokens-title" className="text-base font-bold text-primary-400">Import Tokens</h2>
           <button
+            aria-label="Close import tokens dialog"
             onClick={handleClose}
             disabled={isImporting}
             className="absolute right-6 p-1 hover:bg-secondary/20 rounded transition-colors disabled:opacity-50"

--- a/packages/web-wallet/src/components/ImportTokensDialog.tsx
+++ b/packages/web-wallet/src/components/ImportTokensDialog.tsx
@@ -1,0 +1,425 @@
+import React, { useState, useMemo, useEffect, useRef, useCallback } from 'react';
+import { X, Loader2, ExternalLink, AlertCircle, CheckCircle } from 'lucide-react';
+import { useWallet } from '../contexts/WalletContext';
+import { tokensUtils } from '@hathor/wallet-lib';
+import { truncateString } from '../utils/hathor';
+import { HATHOR_EXPLORER_URLS, NETWORKS } from '../constants';
+import { tokenDiscoveryService, type DiscoveredToken } from '../services/TokenDiscoveryService';
+import { useTokenDiscovery } from '../hooks/useTokenDiscovery';
+
+const BATCH_SIZE = 2;
+const BATCH_INTERVAL_MS = 500;
+
+interface ImportTokensDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Throttled queue that processes items in batches.
+ * Fires BATCH_SIZE requests, waits BATCH_INTERVAL_MS, then fires next batch.
+ */
+function useThrottledQueue(
+  onProcess: (uid: string) => Promise<void>,
+) {
+  const queueRef = useRef<string[]>([]);
+  const isProcessingRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const processNext = useCallback(async () => {
+    if (isProcessingRef.current || queueRef.current.length === 0) return;
+    isProcessingRef.current = true;
+
+    const batch = queueRef.current.splice(0, BATCH_SIZE);
+    await Promise.allSettled(batch.map(uid => onProcess(uid)));
+
+    isProcessingRef.current = false;
+
+    if (queueRef.current.length > 0) {
+      timerRef.current = setTimeout(processNext, BATCH_INTERVAL_MS);
+    }
+  }, [onProcess]);
+
+  const enqueue = useCallback((uids: string[]) => {
+    // Avoid duplicates
+    const existing = new Set(queueRef.current);
+    const newUids = uids.filter(uid => !existing.has(uid));
+    queueRef.current.push(...newUids);
+    processNext();
+  }, [processNext]);
+
+  const clear = useCallback(() => {
+    queueRef.current = [];
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  return { enqueue, clear };
+}
+
+const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
+  isOpen,
+  onClose,
+}) => {
+  const { registerTokensBatch, network, isConnected } = useWallet();
+  const { discoveredTokenUids, refreshDiscovery } = useTokenDiscovery({ isConnected, network });
+
+  // Token details loaded lazily, keyed by UID
+  const [tokenDetails, setTokenDetails] = useState<Map<string, DiscoveredToken>>(new Map());
+  const [selectedTokens, setSelectedTokens] = useState<Set<string>>(new Set());
+  const [isImporting, setIsImporting] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [importSuccess, setImportSuccess] = useState(false);
+
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  const explorerBaseUrl = network === NETWORKS.MAINNET
+    ? HATHOR_EXPLORER_URLS.MAINNET
+    : HATHOR_EXPLORER_URLS.TESTNET;
+
+  // Callback to fetch and store a single token's details
+  const fetchDetail = useCallback(async (uid: string) => {
+    // Skip if already loaded
+    if (tokenDetails.has(uid)) return;
+
+    const detail = await tokenDiscoveryService.fetchTokenDetails(uid);
+    if (detail) {
+      setTokenDetails(prev => {
+        const next = new Map(prev);
+        next.set(uid, detail);
+        return next;
+      });
+    }
+  }, [tokenDetails]);
+
+  const { enqueue, clear } = useThrottledQueue(fetchDetail);
+
+  // When dialog opens, enqueue the first visible tokens
+  useEffect(() => {
+    if (!isOpen || discoveredTokenUids.length === 0) return;
+
+    // Start loading the first batch of visible tokens
+    // (roughly what fits in the 300px scroll area — ~5 items)
+    const initialBatch = discoveredTokenUids.slice(0, 6);
+    enqueue(initialBatch);
+
+    return () => clear();
+  }, [isOpen, discoveredTokenUids, enqueue, clear]);
+
+  // Intersection observer for lazy loading as user scrolls
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  const setupObserver = useCallback(() => {
+    if (observerRef.current) observerRef.current.disconnect();
+
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        const visibleUids: string[] = [];
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            const uid = (entry.target as HTMLElement).dataset.tokenUid;
+            if (uid && !tokenDetails.has(uid)) {
+              visibleUids.push(uid);
+            }
+          }
+        }
+        if (visibleUids.length > 0) {
+          enqueue(visibleUids);
+        }
+      },
+      {
+        root: scrollContainerRef.current,
+        rootMargin: '100px',
+        threshold: 0,
+      }
+    );
+
+    // Observe all token rows
+    const container = scrollContainerRef.current;
+    if (container) {
+      const rows = container.querySelectorAll('[data-token-uid]');
+      rows.forEach(row => observerRef.current?.observe(row));
+    }
+  }, [enqueue, tokenDetails]);
+
+  // Set up intersection observer after token list renders
+  useEffect(() => {
+    if (!isOpen || discoveredTokenUids.length === 0) return;
+
+    // Small delay to let DOM render
+    const timer = setTimeout(setupObserver, 100);
+    return () => {
+      clearTimeout(timer);
+      observerRef.current?.disconnect();
+    };
+  }, [isOpen, discoveredTokenUids, setupObserver]);
+
+  const toggleToken = (uid: string) => {
+    setSelectedTokens(prev => {
+      const next = new Set(prev);
+      if (next.has(uid)) {
+        next.delete(uid);
+      } else {
+        next.add(uid);
+      }
+      return next;
+    });
+  };
+
+  const selectAll = () => {
+    if (selectedTokens.size === discoveredTokenUids.length) {
+      setSelectedTokens(new Set());
+    } else {
+      setSelectedTokens(new Set(discoveredTokenUids));
+    }
+  };
+
+  const formatBalance = (token: DiscoveredToken): string => {
+    if (!token.balance) return '...';
+    const available = token.balance.available;
+    const whole = available / 100n;
+    const remainder = available % 100n;
+    const decimal = remainder.toString().padStart(2, '0');
+    return `${whole.toLocaleString()}.${decimal}`;
+  };
+
+  const handleImport = async () => {
+    if (selectedTokens.size === 0) return;
+
+    setIsImporting(true);
+    setImportError(null);
+
+    // Fetch details for any selected tokens not yet loaded
+    const unloadedUids = [...selectedTokens].filter(uid => !tokenDetails.has(uid));
+    if (unloadedUids.length > 0) {
+      const fetched = await Promise.allSettled(
+        unloadedUids.map(uid => tokenDiscoveryService.fetchTokenDetails(uid))
+      );
+      for (const result of fetched) {
+        if (result.status === 'fulfilled' && result.value) {
+          setTokenDetails(prev => {
+            const next = new Map(prev);
+            next.set(result.value!.uid, result.value!);
+            return next;
+          });
+          // Also update local ref for config string building below
+          tokenDetails.set(result.value.uid, result.value);
+        }
+      }
+    }
+
+    // Build config strings
+    const configStrings: string[] = [];
+    const errors: string[] = [];
+
+    for (const uid of selectedTokens) {
+      const detail = tokenDetails.get(uid);
+      if (!detail?.name || !detail?.symbol) {
+        errors.push(`${uid.slice(0, 8)}...: could not load details`);
+        continue;
+      }
+
+      configStrings.push(
+        tokensUtils.getConfigurationString(detail.uid, detail.name, detail.symbol)
+      );
+    }
+
+    if (configStrings.length > 0) {
+      try {
+        const result = await registerTokensBatch(configStrings);
+        errors.push(...result.errors.map(e => e.error));
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Unknown error';
+        errors.push(`Import failed: ${msg}`);
+      }
+    }
+
+    setIsImporting(false);
+
+    if (errors.length > 0) {
+      setImportError(`Some tokens failed: ${errors.join(', ')}`);
+    } else {
+      setImportSuccess(true);
+      // Re-run discovery so the banner disappears
+      refreshDiscovery();
+      setTimeout(() => handleClose(), 1500);
+    }
+  };
+
+  const handleClose = () => {
+    if (isImporting) return;
+    clear();
+    setSelectedTokens(new Set());
+    setImportError(null);
+    setImportSuccess(false);
+    onClose();
+  };
+
+  const isAllSelected = useMemo(
+    () => discoveredTokenUids.length > 0 && selectedTokens.size === discoveredTokenUids.length,
+    [discoveredTokenUids.length, selectedTokens.size]
+  );
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-start md:items-center justify-center z-50 overflow-y-auto p-4 md:p-0"
+      onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
+    >
+      <div className="bg-[#191C21] border border-[#24292F] rounded-2xl w-full max-w-md my-4 md:my-0 md:mx-4">
+        {/* Header */}
+        <div className="relative flex items-center justify-center p-6 border-b border-[#24292F]">
+          <h2 className="text-base font-bold text-primary-400">Import Tokens</h2>
+          <button
+            onClick={handleClose}
+            disabled={isImporting}
+            className="absolute right-6 p-1 hover:bg-secondary/20 rounded transition-colors disabled:opacity-50"
+          >
+            <X className="w-5 h-5 text-muted-foreground" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-6 space-y-4">
+          {/* Warning */}
+          <div className="bg-green-600/20 border border-green-600/40 rounded-lg px-4 py-3">
+            <p className="text-sm font-bold text-green-400">Check before importing tokens</p>
+            <p className="text-xs text-green-400/80 mt-1">
+              Adding tokens is your responsibility. Make sure you recognize the source.
+            </p>
+          </div>
+
+          {/* Empty state */}
+          {discoveredTokenUids.length === 0 && (
+            <div className="text-center py-8">
+              <p className="text-sm text-muted-foreground">No new tokens found on your wallet.</p>
+            </div>
+          )}
+
+          {/* Token list */}
+          {discoveredTokenUids.length > 0 && (
+            <>
+              <p className="text-sm text-muted-foreground">
+                Select the tokens you want to add to your wallet.
+              </p>
+
+              <div className="flex items-center justify-between">
+                <h3 className="text-sm font-bold text-white">
+                  Tokens found ({discoveredTokenUids.length})
+                </h3>
+                {discoveredTokenUids.length > 1 && (
+                  <button
+                    onClick={selectAll}
+                    className="text-xs text-primary-400 hover:text-primary-300 transition-colors"
+                  >
+                    {isAllSelected ? 'Deselect all' : 'Select all'}
+                  </button>
+                )}
+              </div>
+
+              <div
+                ref={scrollContainerRef}
+                className="max-h-[300px] overflow-y-auto space-y-2 -mx-2 px-2"
+              >
+                {discoveredTokenUids.map((uid) => {
+                  const detail = tokenDetails.get(uid);
+                  const isLoaded = !!detail?.name;
+
+                  return (
+                    <label
+                      key={uid}
+                      data-token-uid={uid}
+                      className="flex items-center gap-3 p-3 bg-[#0D1117] border border-border rounded-lg cursor-pointer hover:bg-[#161B22] transition-colors"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedTokens.has(uid)}
+                        onChange={() => toggleToken(uid)}
+                        className="w-4 h-4 rounded border-border bg-[#0D1117] text-primary accent-primary flex-shrink-0"
+                      />
+                      <div className="flex-1 min-w-0">
+                        {isLoaded ? (
+                          <>
+                            <div className="text-sm font-medium text-white">
+                              {detail!.symbol} ({detail!.name})
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              {formatBalance(detail!)} {detail!.symbol}
+                            </div>
+                          </>
+                        ) : (
+                          <>
+                            <div className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+                              <Loader2 className="w-3 h-3 animate-spin" />
+                              Loading...
+                            </div>
+                            <div className="text-xs text-muted-foreground font-mono">
+                              {truncateString(uid, 8, 8)}
+                            </div>
+                          </>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-1 flex-shrink-0">
+                        <span className="text-xs text-muted-foreground font-mono">
+                          {truncateString(uid, 5, 5)}
+                        </span>
+                        <a
+                          href={`${explorerBaseUrl}/token_detail/${uid}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                          className="p-0.5 hover:text-primary-400 text-muted-foreground transition-colors"
+                        >
+                          <ExternalLink className="w-3.5 h-3.5" />
+                        </a>
+                      </div>
+                    </label>
+                  );
+                })}
+              </div>
+            </>
+          )}
+
+          {/* Error */}
+          {importError && (
+            <div className="flex items-start gap-2 p-3 bg-red-500/10 border border-red-500/50 rounded-lg">
+              <AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+              <span className="text-red-400 text-sm">{importError}</span>
+            </div>
+          )}
+
+          {/* Success */}
+          {importSuccess && (
+            <div className="flex items-start gap-2 p-3 bg-green-500/10 border border-green-500/50 rounded-lg">
+              <CheckCircle className="w-4 h-4 text-green-400 flex-shrink-0 mt-0.5" />
+              <span className="text-green-400 text-sm">Tokens imported successfully!</span>
+            </div>
+          )}
+
+          {/* Continue Button */}
+          {!importSuccess && discoveredTokenUids.length > 0 && (
+            <button
+              onClick={handleImport}
+              disabled={isImporting || selectedTokens.size === 0}
+              className="w-full px-8 py-2.5 bg-primary hover:bg-primary/90 disabled:bg-muted disabled:text-muted-foreground disabled:cursor-not-allowed text-white rounded-lg transition-colors font-medium flex items-center justify-center gap-2"
+            >
+              {isImporting ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Importing tokens...
+                </>
+              ) : (
+                'Continue'
+              )}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ImportTokensDialog;

--- a/packages/web-wallet/src/components/ImportTokensDialog.tsx
+++ b/packages/web-wallet/src/components/ImportTokensDialog.tsx
@@ -380,6 +380,7 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
                         >
                           <input
                             type="checkbox"
+                            aria-label={`Select token ${truncateString(uid, 8, 8)}`}
                             checked={selectedTokens.has(uid)}
                             onChange={() => toggleToken(uid)}
                             className="w-4 h-4 rounded border-border bg-[#0D1117] text-primary accent-primary flex-shrink-0"

--- a/packages/web-wallet/src/components/ImportTokensDialog.tsx
+++ b/packages/web-wallet/src/components/ImportTokensDialog.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useEffect, useRef, useCallback } from 'react';
 import { X, Loader2, ExternalLink, AlertCircle, CheckCircle } from 'lucide-react';
-import { useOutletContext } from 'react-router-dom';
+import { useOutletContext, useNavigate } from 'react-router-dom';
 import { useWallet } from '../contexts/WalletContext';
 import { tokensUtils } from '@hathor/wallet-lib';
 import { truncateString } from '../utils/hathor';
@@ -10,15 +10,13 @@ import { tokenDiscoveryService, type DiscoveredToken } from '../services/TokenDi
 const BATCH_SIZE = 2;
 const BATCH_INTERVAL_MS = 500;
 
+type DialogStep = 'select' | 'confirm' | 'success';
+
 interface ImportTokensDialogProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
-/**
- * Throttled queue that processes items in batches.
- * Fires BATCH_SIZE requests, waits BATCH_INTERVAL_MS, then fires next batch.
- */
 function useThrottledQueue(
   onProcess: (uid: string) => Promise<void>,
 ) {
@@ -41,7 +39,6 @@ function useThrottledQueue(
   }, [onProcess]);
 
   const enqueue = useCallback((uids: string[]) => {
-    // Avoid duplicates
     const existing = new Set(queueRef.current);
     const newUids = uids.filter(uid => !existing.has(uid));
     queueRef.current.push(...newUids);
@@ -64,17 +61,17 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
   onClose,
 }) => {
   const { registerTokensBatch, network } = useWallet();
+  const navigate = useNavigate();
   const { discoveredTokenUids, refreshDiscovery } = useOutletContext<{
     discoveredTokenUids: string[];
     refreshDiscovery: () => Promise<void>;
   }>();
 
-  // Token details loaded lazily, keyed by UID
+  const [step, setStep] = useState<DialogStep>('select');
   const [tokenDetails, setTokenDetails] = useState<Map<string, DiscoveredToken>>(new Map());
   const [selectedTokens, setSelectedTokens] = useState<Set<string>>(new Set());
   const [isImporting, setIsImporting] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
-  const [importSuccess, setImportSuccess] = useState(false);
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
@@ -82,9 +79,8 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
     ? HATHOR_EXPLORER_URLS.MAINNET
     : HATHOR_EXPLORER_URLS.TESTNET;
 
-  // Callback to fetch and store a single token's details
+  // Lazy load token details
   const fetchDetail = useCallback(async (uid: string) => {
-    // Skip if already loaded
     if (tokenDetails.has(uid)) return;
 
     const detail = await tokenDiscoveryService.fetchTokenDetails(uid);
@@ -99,19 +95,14 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
 
   const { enqueue, clear } = useThrottledQueue(fetchDetail);
 
-  // When dialog opens, enqueue the first visible tokens
   useEffect(() => {
     if (!isOpen || discoveredTokenUids.length === 0) return;
-
-    // Start loading the first batch of visible tokens
-    // (roughly what fits in the 300px scroll area — ~5 items)
     const initialBatch = discoveredTokenUids.slice(0, 6);
     enqueue(initialBatch);
-
     return () => clear();
   }, [isOpen, discoveredTokenUids, enqueue, clear]);
 
-  // Intersection observer for lazy loading as user scrolls
+  // Intersection observer for scroll-based lazy loading
   const observerRef = useRef<IntersectionObserver | null>(null);
 
   const setupObserver = useCallback(() => {
@@ -128,45 +119,28 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
             }
           }
         }
-        if (visibleUids.length > 0) {
-          enqueue(visibleUids);
-        }
+        if (visibleUids.length > 0) enqueue(visibleUids);
       },
-      {
-        root: scrollContainerRef.current,
-        rootMargin: '100px',
-        threshold: 0,
-      }
+      { root: scrollContainerRef.current, rootMargin: '100px', threshold: 0 }
     );
 
-    // Observe all token rows
     const container = scrollContainerRef.current;
     if (container) {
-      const rows = container.querySelectorAll('[data-token-uid]');
-      rows.forEach(row => observerRef.current?.observe(row));
+      container.querySelectorAll('[data-token-uid]').forEach(row => observerRef.current?.observe(row));
     }
   }, [enqueue, tokenDetails]);
 
-  // Set up intersection observer after token list renders
   useEffect(() => {
     if (!isOpen || discoveredTokenUids.length === 0) return;
-
-    // Small delay to let DOM render
     const timer = setTimeout(setupObserver, 100);
-    return () => {
-      clearTimeout(timer);
-      observerRef.current?.disconnect();
-    };
+    return () => { clearTimeout(timer); observerRef.current?.disconnect(); };
   }, [isOpen, discoveredTokenUids, setupObserver]);
 
   const toggleToken = (uid: string) => {
     setSelectedTokens(prev => {
       const next = new Set(prev);
-      if (next.has(uid)) {
-        next.delete(uid);
-      } else {
-        next.add(uid);
-      }
+      if (next.has(uid)) next.delete(uid);
+      else next.add(uid);
       return next;
     });
   };
@@ -188,13 +162,11 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
     return `${whole.toLocaleString()}.${decimal}`;
   };
 
-  const handleImport = async () => {
+  // Step 1 → Step 2: fetch any unloaded details for selected tokens, then show confirm
+  const handleContinue = async () => {
     if (selectedTokens.size === 0) return;
 
-    setIsImporting(true);
-    setImportError(null);
-
-    // Fetch details for any selected tokens not yet loaded
+    // Fetch details for unloaded selected tokens
     const unloadedUids = [...selectedTokens].filter(uid => !tokenDetails.has(uid));
     if (unloadedUids.length > 0) {
       const fetched = await Promise.allSettled(
@@ -207,13 +179,19 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
             next.set(result.value!.uid, result.value!);
             return next;
           });
-          // Also update local ref for config string building below
           tokenDetails.set(result.value.uid, result.value);
         }
       }
     }
 
-    // Build config strings
+    setStep('confirm');
+  };
+
+  // Step 2 → Step 3: actually import
+  const handleImport = async () => {
+    setIsImporting(true);
+    setImportError(null);
+
     const configStrings: string[] = [];
     const errors: string[] = [];
 
@@ -223,7 +201,6 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
         errors.push(`${uid.slice(0, 8)}...: could not load details`);
         continue;
       }
-
       configStrings.push(
         tokensUtils.getConfigurationString(detail.uid, detail.name, detail.symbol)
       );
@@ -240,24 +217,21 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
     }
 
     setIsImporting(false);
-
-    // Always re-run discovery so the banner updates (even on partial success)
     refreshDiscovery();
 
     if (errors.length > 0) {
       setImportError(`Some tokens failed: ${errors.join(', ')}`);
     } else {
-      setImportSuccess(true);
-      setTimeout(() => handleClose(), 1500);
+      setStep('success');
     }
   };
 
   const handleClose = () => {
     if (isImporting) return;
     clear();
+    setStep('select');
     setSelectedTokens(new Set());
     setImportError(null);
-    setImportSuccess(false);
     onClose();
   };
 
@@ -266,7 +240,51 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
     [discoveredTokenUids.length, selectedTokens.size]
   );
 
+  // Get selected tokens with details for confirm screen
+  const selectedTokenList = useMemo(() => {
+    return [...selectedTokens]
+      .map(uid => tokenDetails.get(uid))
+      .filter((t): t is DiscoveredToken => !!t?.name);
+  }, [selectedTokens, tokenDetails]);
+
   if (!isOpen) return null;
+
+  // Token row component (reused in select + confirm screens)
+  const TokenRow = ({ token, showCheckbox = false }: { token: DiscoveredToken; showCheckbox?: boolean }) => (
+    <div className="flex items-center gap-3 p-3 bg-[#0D1117] border border-border rounded-lg">
+      {showCheckbox && (
+        <input
+          type="checkbox"
+          checked={selectedTokens.has(token.uid)}
+          onChange={() => toggleToken(token.uid)}
+          className="w-4 h-4 rounded border-border bg-[#0D1117] text-primary accent-primary flex-shrink-0"
+        />
+      )}
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium text-white">
+          {token.symbol} ({token.name})
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {formatBalance(token)} {token.symbol}
+        </div>
+      </div>
+      <div className="flex items-center gap-1 flex-shrink-0">
+        <span className="text-xs text-muted-foreground font-mono">
+          {truncateString(token.uid, 5, 5)}
+        </span>
+        <a
+          href={`${explorerBaseUrl}/token_detail/${token.uid}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          aria-label={`View ${token.symbol} on explorer`}
+          className="p-0.5 hover:text-primary-400 text-muted-foreground transition-colors"
+        >
+          <ExternalLink className="w-3.5 h-3.5" />
+        </a>
+      </div>
+    </div>
+  );
 
   return (
     <div
@@ -276,7 +294,9 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
       <div role="dialog" aria-labelledby="import-tokens-title" className="bg-[#191C21] border border-[#24292F] rounded-2xl w-full max-w-md my-4 md:my-0 md:mx-4">
         {/* Header */}
         <div className="relative flex items-center justify-center p-6 border-b border-[#24292F]">
-          <h2 id="import-tokens-title" className="text-base font-bold text-primary-400">Import Tokens</h2>
+          <h2 id="import-tokens-title" className="text-base font-bold text-primary-400">
+            {step === 'confirm' ? 'Confirm import' : 'Import Tokens'}
+          </h2>
           <button
             aria-label="Close import tokens dialog"
             onClick={handleClose}
@@ -287,76 +307,71 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
           </button>
         </div>
 
-        {/* Content */}
         <div className="p-6 space-y-4">
-          {/* Warning */}
-          <div className="bg-green-600/20 border border-green-600/40 rounded-lg px-4 py-3">
-            <p className="text-sm font-bold text-green-400">Check before importing tokens</p>
-            <p className="text-xs text-green-400/80 mt-1">
-              Adding tokens is your responsibility. Make sure you recognize the source.
-            </p>
-          </div>
-
-          {/* Empty state */}
-          {discoveredTokenUids.length === 0 && (
-            <div className="text-center py-8">
-              <p className="text-sm text-muted-foreground">No new tokens found on your wallet.</p>
-            </div>
-          )}
-
-          {/* Token list */}
-          {discoveredTokenUids.length > 0 && (
+          {/* ===== STEP 1: SELECT ===== */}
+          {step === 'select' && (
             <>
-              <p className="text-sm text-muted-foreground">
-                Select the tokens you want to add to your wallet.
-              </p>
-
-              <div className="flex items-center justify-between">
-                <h3 className="text-sm font-bold text-white">
-                  Tokens found ({discoveredTokenUids.length})
-                </h3>
-                {discoveredTokenUids.length > 1 && (
-                  <button
-                    onClick={selectAll}
-                    className="text-xs text-primary-400 hover:text-primary-300 transition-colors"
-                  >
-                    {isAllSelected ? 'Deselect all' : 'Select all'}
-                  </button>
-                )}
+              {/* Warning */}
+              <div className="bg-green-600/20 border border-green-600/40 rounded-lg px-4 py-3">
+                <p className="text-sm font-bold text-green-400">Check before importing tokens</p>
+                <p className="text-xs text-green-400/80 mt-1">
+                  Adding tokens is your responsibility. Make sure you recognize the source.
+                </p>
               </div>
 
-              <div
-                ref={scrollContainerRef}
-                className="max-h-[300px] overflow-y-auto space-y-2 -mx-2 px-2"
-              >
-                {discoveredTokenUids.map((uid) => {
-                  const detail = tokenDetails.get(uid);
-                  const isLoaded = !!detail?.name;
+              {/* Empty state */}
+              {discoveredTokenUids.length === 0 && (
+                <div className="text-center py-8">
+                  <p className="text-sm text-muted-foreground">No new tokens found on your wallet.</p>
+                </div>
+              )}
 
-                  return (
-                    <label
-                      key={uid}
-                      data-token-uid={uid}
-                      className="flex items-center gap-3 p-3 bg-[#0D1117] border border-border rounded-lg cursor-pointer hover:bg-[#161B22] transition-colors"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={selectedTokens.has(uid)}
-                        onChange={() => toggleToken(uid)}
-                        className="w-4 h-4 rounded border-border bg-[#0D1117] text-primary accent-primary flex-shrink-0"
-                      />
-                      <div className="flex-1 min-w-0">
-                        {isLoaded ? (
-                          <>
-                            <div className="text-sm font-medium text-white">
-                              {detail!.symbol} ({detail!.name})
-                            </div>
-                            <div className="text-xs text-muted-foreground">
-                              {formatBalance(detail!)} {detail!.symbol}
-                            </div>
-                          </>
-                        ) : (
-                          <>
+              {/* Token list */}
+              {discoveredTokenUids.length > 0 && (
+                <>
+                  <p className="text-sm text-muted-foreground">
+                    Select the tokens you want to add to your wallet.
+                  </p>
+
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-sm font-bold text-white">
+                      Tokens found ({discoveredTokenUids.length})
+                    </h3>
+                    {discoveredTokenUids.length > 1 && (
+                      <button
+                        onClick={selectAll}
+                        className="text-xs text-primary-400 hover:text-primary-300 transition-colors"
+                      >
+                        {isAllSelected ? 'Deselect all' : 'Select all'}
+                      </button>
+                    )}
+                  </div>
+
+                  <div
+                    ref={scrollContainerRef}
+                    className="max-h-[300px] overflow-y-auto space-y-2 -mx-2 px-2"
+                  >
+                    {discoveredTokenUids.map((uid) => {
+                      const detail = tokenDetails.get(uid);
+                      const isLoaded = !!detail?.name;
+
+                      return isLoaded ? (
+                        <label key={uid} data-token-uid={uid} className="cursor-pointer block">
+                          <TokenRow token={detail!} showCheckbox />
+                        </label>
+                      ) : (
+                        <div
+                          key={uid}
+                          data-token-uid={uid}
+                          className="flex items-center gap-3 p-3 bg-[#0D1117] border border-border rounded-lg"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={selectedTokens.has(uid)}
+                            onChange={() => toggleToken(uid)}
+                            className="w-4 h-4 rounded border-border bg-[#0D1117] text-primary accent-primary flex-shrink-0"
+                          />
+                          <div className="flex-1 min-w-0">
                             <div className="text-sm font-medium text-muted-foreground flex items-center gap-2">
                               <Loader2 className="w-3 h-3 animate-spin" />
                               Loading...
@@ -364,62 +379,110 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
                             <div className="text-xs text-muted-foreground font-mono">
                               {truncateString(uid, 8, 8)}
                             </div>
-                          </>
-                        )}
-                      </div>
-                      <div className="flex items-center gap-1 flex-shrink-0">
-                        <span className="text-xs text-muted-foreground font-mono">
-                          {truncateString(uid, 5, 5)}
-                        </span>
-                        <a
-                          href={`${explorerBaseUrl}/token_detail/${uid}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          onClick={(e) => e.stopPropagation()}
-                          className="p-0.5 hover:text-primary-400 text-muted-foreground transition-colors"
-                        >
-                          <ExternalLink className="w-3.5 h-3.5" />
-                        </a>
-                      </div>
-                    </label>
-                  );
-                })}
+                          </div>
+                          <div className="flex items-center gap-1 flex-shrink-0">
+                            <span className="text-xs text-muted-foreground font-mono">
+                              {truncateString(uid, 5, 5)}
+                            </span>
+                            <a
+                              href={`${explorerBaseUrl}/token_detail/${uid}`}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              aria-label="View token on explorer"
+                              className="p-0.5 hover:text-primary-400 text-muted-foreground transition-colors"
+                            >
+                              <ExternalLink className="w-3.5 h-3.5" />
+                            </a>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+
+                  {/* Continue Button */}
+                  <button
+                    onClick={handleContinue}
+                    disabled={selectedTokens.size === 0}
+                    className="w-full px-8 py-2.5 bg-primary hover:bg-primary/90 disabled:bg-muted disabled:text-muted-foreground disabled:cursor-not-allowed text-white rounded-lg transition-colors font-medium"
+                  >
+                    Continue
+                  </button>
+                </>
+              )}
+            </>
+          )}
+
+          {/* ===== STEP 2: CONFIRM ===== */}
+          {step === 'confirm' && (
+            <>
+              <p className="text-sm text-muted-foreground">
+                You are about to add these tokens to your wallet:
+              </p>
+
+              <div className="max-h-[300px] overflow-y-auto space-y-2 -mx-2 px-2">
+                {selectedTokenList.map((token) => (
+                  <TokenRow key={token.uid} token={token} />
+                ))}
+              </div>
+
+              {/* Error */}
+              {importError && (
+                <div className="flex items-start gap-2 p-3 bg-red-500/10 border border-red-500/50 rounded-lg">
+                  <AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+                  <span className="text-red-400 text-sm">{importError}</span>
+                </div>
+              )}
+
+              {/* Action Buttons */}
+              <div className="flex gap-3">
+                <button
+                  onClick={() => { setStep('select'); setImportError(null); }}
+                  disabled={isImporting}
+                  className="flex-1 px-4 py-2.5 bg-[#0D1117] border border-border hover:bg-[#161B22] text-white rounded-lg transition-colors font-medium"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleImport}
+                  disabled={isImporting}
+                  className="flex-1 px-4 py-2.5 bg-primary hover:bg-primary/90 disabled:bg-muted disabled:text-muted-foreground text-white rounded-lg transition-colors font-medium flex items-center justify-center gap-2"
+                >
+                  {isImporting ? (
+                    <>
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                      Importing...
+                    </>
+                  ) : (
+                    'Import tokens'
+                  )}
+                </button>
               </div>
             </>
           )}
 
-          {/* Error */}
-          {importError && (
-            <div className="flex items-start gap-2 p-3 bg-red-500/10 border border-red-500/50 rounded-lg">
-              <AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
-              <span className="text-red-400 text-sm">{importError}</span>
-            </div>
-          )}
+          {/* ===== STEP 3: SUCCESS ===== */}
+          {step === 'success' && (
+            <>
+              <div className="flex items-center gap-2 py-2">
+                <CheckCircle className="w-5 h-5 text-green-400" />
+                <span className="text-sm font-medium text-white">Tokens imported!</span>
+              </div>
 
-          {/* Success */}
-          {importSuccess && (
-            <div className="flex items-start gap-2 p-3 bg-green-500/10 border border-green-500/50 rounded-lg">
-              <CheckCircle className="w-4 h-4 text-green-400 flex-shrink-0 mt-0.5" />
-              <span className="text-green-400 text-sm">Tokens imported successfully!</span>
-            </div>
-          )}
-
-          {/* Continue Button */}
-          {!importSuccess && discoveredTokenUids.length > 0 && (
-            <button
-              onClick={handleImport}
-              disabled={isImporting || selectedTokens.size === 0}
-              className="w-full px-8 py-2.5 bg-primary hover:bg-primary/90 disabled:bg-muted disabled:text-muted-foreground disabled:cursor-not-allowed text-white rounded-lg transition-colors font-medium flex items-center justify-center gap-2"
-            >
-              {isImporting ? (
-                <>
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                  Importing tokens...
-                </>
-              ) : (
-                'Continue'
-              )}
-            </button>
+              <div className="flex gap-3">
+                <button
+                  onClick={handleClose}
+                  className="flex-1 px-4 py-2.5 bg-[#0D1117] border border-border hover:bg-[#161B22] text-white rounded-lg transition-colors font-medium"
+                >
+                  Close
+                </button>
+                <button
+                  onClick={() => { handleClose(); navigate('/?filter=tokens'); }}
+                  className="flex-1 px-4 py-2.5 bg-primary hover:bg-primary/90 text-white rounded-lg transition-colors font-medium"
+                >
+                  See all tokens
+                </button>
+              </div>
+            </>
           )}
         </div>
       </div>

--- a/packages/web-wallet/src/components/ImportTokensDialog.tsx
+++ b/packages/web-wallet/src/components/ImportTokensDialog.tsx
@@ -311,13 +311,15 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
           {/* ===== STEP 1: SELECT ===== */}
           {step === 'select' && (
             <>
-              {/* Warning */}
-              <div className="bg-green-600/20 border border-green-600/40 rounded-lg px-4 py-3">
-                <p className="text-sm font-bold text-green-400">Check before importing tokens</p>
-                <p className="text-xs text-green-400/80 mt-1">
-                  Adding tokens is your responsibility. Make sure you recognize the source.
-                </p>
-              </div>
+              {/* Warning - only show when there are tokens */}
+              {discoveredTokenUids.length > 0 && (
+                <div className="bg-green-600/20 border border-green-600/40 rounded-lg px-4 py-3">
+                  <p className="text-sm font-bold text-green-400">Check before importing tokens</p>
+                  <p className="text-xs text-green-400/80 mt-1">
+                    Adding tokens is your responsibility. Make sure you recognize the source.
+                  </p>
+                </div>
+              )}
 
               {/* Empty state */}
               {discoveredTokenUids.length === 0 && (

--- a/packages/web-wallet/src/components/ImportTokensDialog.tsx
+++ b/packages/web-wallet/src/components/ImportTokensDialog.tsx
@@ -221,8 +221,13 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
       }
     }
 
+    try {
+      await refreshDiscovery();
+    } catch {
+      // non-fatal
+    }
+
     setIsImporting(false);
-    refreshDiscovery();
 
     if (errors.length > 0) {
       setImportError(`Some tokens failed: ${errors.join(', ')}`);

--- a/packages/web-wallet/src/components/ImportTokensDialog.tsx
+++ b/packages/web-wallet/src/components/ImportTokensDialog.tsx
@@ -434,6 +434,14 @@ const ImportTokensDialog: React.FC<ImportTokensDialogProps> = ({
                     })}
                   </div>
 
+                  {/* Error from failed import */}
+                  {importError && (
+                    <div className="flex items-start gap-2 p-3 bg-red-500/10 border border-red-500/50 rounded-lg">
+                      <AlertCircle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+                      <span className="text-red-400 text-sm">{importError}</span>
+                    </div>
+                  )}
+
                   {/* Continue Button */}
                   <button
                     onClick={handleContinue}

--- a/packages/web-wallet/src/components/NewTokensBanner.tsx
+++ b/packages/web-wallet/src/components/NewTokensBanner.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { X, Info } from 'lucide-react';
+
+interface NewTokensBannerProps {
+  tokenCount: number;
+  onImportClick: () => void;
+  onDismiss: () => void;
+}
+
+const NewTokensBanner: React.FC<NewTokensBannerProps> = ({
+  tokenCount,
+  onImportClick,
+  onDismiss,
+}) => {
+  if (tokenCount === 0) return null;
+
+  return (
+    <div className="bg-green-600/90 rounded-xl px-4 py-3 flex items-center justify-between gap-3">
+      <div className="flex items-center gap-3 min-w-0">
+        <Info className="w-5 h-5 text-white flex-shrink-0" />
+        <p className="text-sm text-white">
+          <span className="font-bold">New tokens</span>
+          {' '}
+          We found tokens linked to your address that are not yet in your wallet.
+          {' '}
+          <button
+            onClick={onImportClick}
+            className="font-bold underline hover:text-white/90 transition-colors"
+          >
+            Import tokens.
+          </button>
+        </p>
+      </div>
+      <button
+        onClick={onDismiss}
+        className="p-1 hover:bg-white/20 rounded transition-colors flex-shrink-0"
+      >
+        <X className="w-4 h-4 text-white" />
+      </button>
+    </div>
+  );
+};
+
+export default NewTokensBanner;

--- a/packages/web-wallet/src/components/NewTokensBanner.tsx
+++ b/packages/web-wallet/src/components/NewTokensBanner.tsx
@@ -3,12 +3,14 @@ import { X, Info } from 'lucide-react';
 
 interface NewTokensBannerProps {
   tokenCount: number;
+  isSingleAddress: boolean;
   onImportClick: () => void;
   onDismiss: () => void;
 }
 
 const NewTokensBanner: React.FC<NewTokensBannerProps> = ({
   tokenCount,
+  isSingleAddress,
   onImportClick,
   onDismiss,
 }) => {
@@ -21,7 +23,7 @@ const NewTokensBanner: React.FC<NewTokensBannerProps> = ({
         <p className="text-sm text-white">
           <span className="font-bold">New tokens</span>
           {' '}
-          We found tokens linked to your address that are not yet in your wallet.
+          We found tokens linked to your address{isSingleAddress ? '' : 'es'} that are not yet in your wallet.
           {' '}
           <button
             onClick={onImportClick}

--- a/packages/web-wallet/src/components/NewTokensBanner.tsx
+++ b/packages/web-wallet/src/components/NewTokensBanner.tsx
@@ -15,7 +15,7 @@ const NewTokensBanner: React.FC<NewTokensBannerProps> = ({
   if (tokenCount === 0) return null;
 
   return (
-    <div className="bg-green-600/90 rounded-xl px-4 py-3 flex items-center justify-between gap-3">
+    <div className="bg-primary/90 rounded-xl px-4 py-3 flex items-center justify-between gap-3">
       <div className="flex items-center gap-3 min-w-0">
         <Info className="w-5 h-5 text-white flex-shrink-0" />
         <p className="text-sm text-white">

--- a/packages/web-wallet/src/components/NewTokensBanner.tsx
+++ b/packages/web-wallet/src/components/NewTokensBanner.tsx
@@ -32,6 +32,8 @@ const NewTokensBanner: React.FC<NewTokensBannerProps> = ({
         </p>
       </div>
       <button
+        type="button"
+        aria-label="Dismiss new tokens banner"
         onClick={onDismiss}
         className="p-1 hover:bg-white/20 rounded transition-colors flex-shrink-0"
       >

--- a/packages/web-wallet/src/components/WalletHome.tsx
+++ b/packages/web-wallet/src/components/WalletHome.tsx
@@ -36,6 +36,7 @@ const WalletHome: React.FC = () => {
     discoveredTokenUids,
     isDismissed,
     dismissBanner,
+    refreshDiscovery,
   } = useTokenDiscovery({ isConnected, network });
 
   // Derive filter from URL search params
@@ -271,7 +272,7 @@ const WalletHome: React.FC = () => {
       </div>
 
       {/* Nested routes (dialogs) rendered here */}
-      <Outlet />
+      <Outlet context={{ discoveredTokenUids, refreshDiscovery }} />
     </div>
   );
 };

--- a/packages/web-wallet/src/components/WalletHome.tsx
+++ b/packages/web-wallet/src/components/WalletHome.tsx
@@ -4,8 +4,10 @@ import { ArrowUpRight, ArrowDownLeft, Loader2, Eye } from 'lucide-react';
 import TokenTabs from './TokenTabs';
 import TokenList from './TokenList';
 import Header from './Header';
+import NewTokensBanner from './NewTokensBanner';
 import { useWallet } from '../contexts/WalletContext';
 import { useTokens } from '../hooks/useTokens';
+import { useTokenDiscovery } from '../hooks/useTokenDiscovery';
 import { formatAmount } from '../utils/hathor';
 import { TOKEN_IDS } from '../constants';
 import htrLogoBlack from '../assets/htr_logo_black.svg';
@@ -27,7 +29,14 @@ const WalletHome: React.FC = () => {
     setError,
     newTransaction,
     clearNewTransaction,
+    network,
   } = useWallet();
+
+  const {
+    discoveredTokenUids,
+    isDismissed,
+    dismissBanner,
+  } = useTokenDiscovery({ isConnected, network });
 
   // Derive filter from URL search params
   const filterParam = searchParams.get('filter') as 'all' | 'tokens' | 'nfts' | null;
@@ -172,10 +181,21 @@ const WalletHome: React.FC = () => {
         onRegisterTokenClick={() => navigate('/register-token')}
         onCreateTokenClick={() => navigate('/create-token')}
         onAddressModeClick={() => navigate('/address-mode')}
+        onImportTokensClick={() => navigate('/import-tokens')}
+        hasDiscoveredTokens={discoveredTokenUids.length > 0}
       />
 
       {/* Main Container - responsive layout */}
       <div className='max-w-7xl mx-auto px-4 md:px-8 lg:px-16 py-6 md:py-9 space-y-8 md:space-y-20'>
+        {/* New Tokens Banner */}
+        {discoveredTokenUids.length > 0 && !isDismissed && (
+          <NewTokensBanner
+            tokenCount={discoveredTokenUids.length}
+            onImportClick={() => navigate('/import-tokens')}
+            onDismiss={dismissBanner}
+          />
+        )}
+
         {/* Assets Summary Card */}
         <div className='bg-[#191C21] border border-[#24292F] rounded-2xl p-4 md:p-6'>
           <div className='flex flex-col md:flex-row md:items-center md:justify-between gap-4 md:gap-0'>

--- a/packages/web-wallet/src/components/WalletHome.tsx
+++ b/packages/web-wallet/src/components/WalletHome.tsx
@@ -183,7 +183,6 @@ const WalletHome: React.FC = () => {
         onCreateTokenClick={() => navigate('/create-token')}
         onAddressModeClick={() => navigate('/address-mode')}
         onImportTokensClick={() => navigate('/import-tokens')}
-        hasDiscoveredTokens={discoveredTokenUids.length > 0}
       />
 
       {/* Main Container - responsive layout */}

--- a/packages/web-wallet/src/components/WalletHome.tsx
+++ b/packages/web-wallet/src/components/WalletHome.tsx
@@ -30,6 +30,7 @@ const WalletHome: React.FC = () => {
     newTransaction,
     clearNewTransaction,
     network,
+    addressMode,
   } = useWallet();
 
   const {
@@ -191,6 +192,7 @@ const WalletHome: React.FC = () => {
         {discoveredTokenUids.length > 0 && !isDismissed && (
           <NewTokensBanner
             tokenCount={discoveredTokenUids.length}
+            isSingleAddress={addressMode === 'single'}
             onImportClick={() => navigate('/import-tokens')}
             onDismiss={dismissBanner}
           />

--- a/packages/web-wallet/src/components/WalletHome.tsx
+++ b/packages/web-wallet/src/components/WalletHome.tsx
@@ -37,7 +37,7 @@ const WalletHome: React.FC = () => {
     isDismissed,
     dismissBanner,
     refreshDiscovery,
-  } = useTokenDiscovery({ isConnected, network });
+  } = useTokenDiscovery({ isConnected, network, newTransaction });
 
   // Derive filter from URL search params
   const filterParam = searchParams.get('filter') as 'all' | 'tokens' | 'nfts' | null;

--- a/packages/web-wallet/src/components/__tests__/ImportTokensDialog.test.tsx
+++ b/packages/web-wallet/src/components/__tests__/ImportTokensDialog.test.tsx
@@ -2,10 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-const { mockUseWallet, mockFetchTokenDetails, mockDiscoverTokenUids } = vi.hoisted(() => ({
+const { mockUseWallet, mockFetchTokenDetails } = vi.hoisted(() => ({
   mockUseWallet: vi.fn(),
   mockFetchTokenDetails: vi.fn(),
-  mockDiscoverTokenUids: vi.fn(),
 }));
 
 vi.mock('../../contexts/WalletContext', () => ({
@@ -15,10 +14,10 @@ vi.mock('../../contexts/WalletContext', () => ({
 vi.mock('../../services/TokenDiscoveryService', () => ({
   tokenDiscoveryService: {
     fetchTokenDetails: mockFetchTokenDetails,
-    discoverTokenUids: mockDiscoverTokenUids,
   },
 }));
 
+const mockNavigate = vi.fn();
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
   return {
@@ -27,6 +26,7 @@ vi.mock('react-router-dom', async () => {
       discoveredTokenUids: ['token-b-uid', 'token-c-uid'],
       refreshDiscovery: vi.fn().mockResolvedValue(undefined),
     }),
+    useNavigate: () => mockNavigate,
   };
 });
 
@@ -53,6 +53,14 @@ vi.mock('../../constants', () => ({
   },
 }));
 
+// Mock IntersectionObserver (not available in jsdom)
+class MockIntersectionObserver {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+
 import ImportTokensDialog from '../ImportTokensDialog';
 
 describe('ImportTokensDialog', () => {
@@ -69,16 +77,15 @@ describe('ImportTokensDialog', () => {
       isConnected: true,
     });
 
-    mockFetchTokenDetails
-      .mockImplementation(async (uid: string) => {
-        if (uid === 'token-b-uid') {
-          return { uid: 'token-b-uid', name: 'TokenB', symbol: 'TKB', balance: { available: 20000n, locked: 0n } };
-        }
-        if (uid === 'token-c-uid') {
-          return { uid: 'token-c-uid', name: 'TokenC', symbol: 'TKC', balance: { available: 50076n, locked: 10n } };
-        }
-        return null;
-      });
+    mockFetchTokenDetails.mockImplementation(async (uid: string) => {
+      if (uid === 'token-b-uid') {
+        return { uid: 'token-b-uid', name: 'TokenB', symbol: 'TKB', balance: { available: 20000n, locked: 0n } };
+      }
+      if (uid === 'token-c-uid') {
+        return { uid: 'token-c-uid', name: 'TokenC', symbol: 'TKC', balance: { available: 50076n, locked: 10n } };
+      }
+      return null;
+    });
 
     mockRegisterTokensBatch.mockResolvedValue({ registered: [], errors: [] });
   });
@@ -92,66 +99,41 @@ describe('ImportTokensDialog', () => {
     expect(screen.queryByText('Import Tokens')).not.toBeInTheDocument();
   });
 
-  it('should render dialog with token UIDs and lazy load details', async () => {
+  it('should render select step with token list', async () => {
     render(<ImportTokensDialog isOpen={true} onClose={mockOnClose} />);
 
     expect(screen.getByText('Import Tokens')).toBeInTheDocument();
-    expect(screen.getByText('Check before importing tokens')).toBeInTheDocument();
     expect(screen.getByText('Tokens found (2)')).toBeInTheDocument();
 
-    // Details load lazily
     await waitFor(() => {
       expect(screen.getByText('TKB (TokenB)')).toBeInTheDocument();
     });
   });
 
-  it('should enable Continue button only when tokens are selected', async () => {
+  it('should show confirm step after selecting tokens and clicking Continue', async () => {
     render(<ImportTokensDialog isOpen={true} onClose={mockOnClose} />);
 
     await waitFor(() => {
       expect(screen.getByText('TKB (TokenB)')).toBeInTheDocument();
     });
 
-    const continueButton = screen.getByRole('button', { name: 'Continue' });
-    expect(continueButton).toBeDisabled();
-
+    // Select a token
     const checkboxes = screen.getAllByRole('checkbox');
     await userEvent.click(checkboxes[0]);
 
-    expect(continueButton).not.toBeDisabled();
-  });
+    // Click Continue
+    await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
-  it('should toggle token selection on checkbox click', async () => {
-    render(<ImportTokensDialog isOpen={true} onClose={mockOnClose} />);
-
+    // Should show confirm step
     await waitFor(() => {
-      expect(screen.getByText('TKB (TokenB)')).toBeInTheDocument();
+      expect(screen.getByText('Confirm import')).toBeInTheDocument();
+      expect(screen.getByText('You are about to add these tokens to your wallet:')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Import tokens' })).toBeInTheDocument();
     });
-
-    const checkboxes = screen.getAllByRole('checkbox');
-
-    await userEvent.click(checkboxes[0]);
-    expect(checkboxes[0]).toBeChecked();
-
-    await userEvent.click(checkboxes[0]);
-    expect(checkboxes[0]).not.toBeChecked();
   });
 
-  it('should select all tokens when Select all is clicked', async () => {
-    render(<ImportTokensDialog isOpen={true} onClose={mockOnClose} />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Tokens found (2)')).toBeInTheDocument();
-    });
-
-    await userEvent.click(screen.getByText('Select all'));
-
-    const checkboxes = screen.getAllByRole('checkbox');
-    expect(checkboxes[0]).toBeChecked();
-    expect(checkboxes[1]).toBeChecked();
-  });
-
-  it('should import selected tokens on Continue click', async () => {
+  it('should go back to select step when Cancel is clicked on confirm', async () => {
     render(<ImportTokensDialog isOpen={true} onClose={mockOnClose} />);
 
     await waitFor(() => {
@@ -163,12 +145,42 @@ describe('ImportTokensDialog', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
     await waitFor(() => {
-      expect(mockRegisterTokensBatch).toHaveBeenCalledOnce();
-      expect(screen.getByText('Tokens imported successfully!')).toBeInTheDocument();
+      expect(screen.getByText('Confirm import')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Tokens found (2)')).toBeInTheDocument();
     });
   });
 
-  it('should show error when import fails', async () => {
+  it('should show success step after importing', async () => {
+    render(<ImportTokensDialog isOpen={true} onClose={mockOnClose} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('TKB (TokenB)')).toBeInTheDocument();
+    });
+
+    // Select + Continue + Import
+    const checkboxes = screen.getAllByRole('checkbox');
+    await userEvent.click(checkboxes[0]);
+    await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Import tokens' })).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Import tokens' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Tokens imported!')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'See all tokens' })).toBeInTheDocument();
+    });
+  });
+
+  it('should show error on confirm step when import fails', async () => {
     mockRegisterTokensBatch.mockResolvedValue({ registered: [], errors: [{ configString: 'x', error: 'Registration failed' }] });
 
     render(<ImportTokensDialog isOpen={true} onClose={mockOnClose} />);
@@ -182,20 +194,39 @@ describe('ImportTokensDialog', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
 
     await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Import tokens' })).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Import tokens' }));
+
+    await waitFor(() => {
       expect(screen.getByText(/failed/i)).toBeInTheDocument();
     });
   });
 
-  it('should have explorer links for each token', async () => {
+  it('should navigate to tokens filter when See all tokens is clicked', async () => {
     render(<ImportTokensDialog isOpen={true} onClose={mockOnClose} />);
 
     await waitFor(() => {
-      expect(screen.getByText('Tokens found (2)')).toBeInTheDocument();
+      expect(screen.getByText('TKB (TokenB)')).toBeInTheDocument();
     });
 
-    const links = screen.getAllByRole('link');
-    expect(links).toHaveLength(2);
-    expect(links[0]).toHaveAttribute('href', expect.stringContaining('token_detail/token-b-uid'));
-    expect(links[1]).toHaveAttribute('href', expect.stringContaining('token_detail/token-c-uid'));
+    const checkboxes = screen.getAllByRole('checkbox');
+    await userEvent.click(checkboxes[0]);
+    await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Import tokens' })).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Import tokens' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'See all tokens' })).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'See all tokens' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/?filter=tokens');
   });
 });

--- a/packages/web-wallet/src/components/__tests__/ImportTokensDialog.test.tsx
+++ b/packages/web-wallet/src/components/__tests__/ImportTokensDialog.test.tsx
@@ -20,7 +20,7 @@ vi.mock('../../services/TokenDiscoveryService', () => ({
 }));
 
 vi.mock('../../hooks/useTokenDiscovery', () => ({
-  useTokenDiscovery: ({ isConnected: _c, network: _n }: { isConnected: boolean; network: string }) => ({
+  useTokenDiscovery: () => ({
     discoveredTokenUids: ['token-b-uid', 'token-c-uid'],
     isDiscovering: false,
     isDismissed: false,

--- a/packages/web-wallet/src/components/__tests__/ImportTokensDialog.test.tsx
+++ b/packages/web-wallet/src/components/__tests__/ImportTokensDialog.test.tsx
@@ -19,15 +19,16 @@ vi.mock('../../services/TokenDiscoveryService', () => ({
   },
 }));
 
-vi.mock('../../hooks/useTokenDiscovery', () => ({
-  useTokenDiscovery: () => ({
-    discoveredTokenUids: ['token-b-uid', 'token-c-uid'],
-    isDiscovering: false,
-    isDismissed: false,
-    dismissBanner: vi.fn(),
-    refreshDiscovery: vi.fn().mockResolvedValue(undefined),
-  }),
-}));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useOutletContext: () => ({
+      discoveredTokenUids: ['token-b-uid', 'token-c-uid'],
+      refreshDiscovery: vi.fn().mockResolvedValue(undefined),
+    }),
+  };
+});
 
 vi.mock('@hathor/wallet-lib', () => ({
   tokensUtils: {

--- a/packages/web-wallet/src/components/__tests__/ImportTokensDialog.test.tsx
+++ b/packages/web-wallet/src/components/__tests__/ImportTokensDialog.test.tsx
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const { mockUseWallet, mockFetchTokenDetails, mockDiscoverTokenUids } = vi.hoisted(() => ({
+  mockUseWallet: vi.fn(),
+  mockFetchTokenDetails: vi.fn(),
+  mockDiscoverTokenUids: vi.fn(),
+}));
+
+vi.mock('../../contexts/WalletContext', () => ({
+  useWallet: mockUseWallet,
+}));
+
+vi.mock('../../services/TokenDiscoveryService', () => ({
+  tokenDiscoveryService: {
+    fetchTokenDetails: mockFetchTokenDetails,
+    discoverTokenUids: mockDiscoverTokenUids,
+  },
+}));
+
+vi.mock('../../hooks/useTokenDiscovery', () => ({
+  useTokenDiscovery: ({ isConnected: _c, network: _n }: { isConnected: boolean; network: string }) => ({
+    discoveredTokenUids: ['token-b-uid', 'token-c-uid'],
+    isDiscovering: false,
+    isDismissed: false,
+    dismissBanner: vi.fn(),
+    refreshDiscovery: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+vi.mock('@hathor/wallet-lib', () => ({
+  tokensUtils: {
+    getConfigurationString: vi.fn((uid: string, name: string, symbol: string) =>
+      `[${name}:${symbol}:${uid}:checksum]`
+    ),
+  },
+}));
+
+vi.mock('../../utils/hathor', () => ({
+  truncateString: (str: string, start = 5, end = 5) => `${str.slice(0, start)}...${str.slice(-end)}`,
+}));
+
+vi.mock('../../constants', () => ({
+  HATHOR_EXPLORER_URLS: {
+    MAINNET: 'https://explorer.hathor.network',
+    TESTNET: 'https://explorer.testnet.hathor.network',
+  },
+  NETWORKS: {
+    MAINNET: 'mainnet',
+    TESTNET: 'testnet',
+  },
+}));
+
+import ImportTokensDialog from '../ImportTokensDialog';
+
+describe('ImportTokensDialog', () => {
+  const mockOnClose = vi.fn();
+  const mockRegisterTokensBatch = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    mockUseWallet.mockReturnValue({
+      registerTokensBatch: mockRegisterTokensBatch,
+      network: 'mainnet',
+      isConnected: true,
+    });
+
+    mockFetchTokenDetails
+      .mockImplementation(async (uid: string) => {
+        if (uid === 'token-b-uid') {
+          return { uid: 'token-b-uid', name: 'TokenB', symbol: 'TKB', balance: { available: 20000n, locked: 0n } };
+        }
+        if (uid === 'token-c-uid') {
+          return { uid: 'token-c-uid', name: 'TokenC', symbol: 'TKC', balance: { available: 50076n, locked: 10n } };
+        }
+        return null;
+      });
+
+    mockRegisterTokensBatch.mockResolvedValue({ registered: [], errors: [] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should not render when isOpen is false', () => {
+    render(<ImportTokensDialog isOpen={false} onClose={mockOnClose} />);
+    expect(screen.queryByText('Import Tokens')).not.toBeInTheDocument();
+  });
+
+  it('should render dialog with token UIDs and lazy load details', async () => {
+    render(<ImportTokensDialog isOpen={true} onClose={mockOnClose} />);
+
+    expect(screen.getByText('Import Tokens')).toBeInTheDocument();
+    expect(screen.getByText('Check before importing tokens')).toBeInTheDocument();
+    expect(screen.getByText('Tokens found (2)')).toBeInTheDocument();
+
+    // Details load lazily
+    await waitFor(() => {
+      expect(screen.getByText('TKB (TokenB)')).toBeInTheDocument();
+    });
+  });
+
+  it('should enable Continue button only when tokens are selected', async () => {
+    render(<ImportTokensDialog isOpen={true} onClose={mockOnClose} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('TKB (TokenB)')).toBeInTheDocument();
+    });
+
+    const continueButton = screen.getByRole('button', { name: 'Continue' });
+    expect(continueButton).toBeDisabled();
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    await userEvent.click(checkboxes[0]);
+
+    expect(continueButton).not.toBeDisabled();
+  });
+
+  it('should toggle token selection on checkbox click', async () => {
+    render(<ImportTokensDialog isOpen={true} onClose={mockOnClose} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('TKB (TokenB)')).toBeInTheDocument();
+    });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+
+    await userEvent.click(checkboxes[0]);
+    expect(checkboxes[0]).toBeChecked();
+
+    await userEvent.click(checkboxes[0]);
+    expect(checkboxes[0]).not.toBeChecked();
+  });
+
+  it('should select all tokens when Select all is clicked', async () => {
+    render(<ImportTokensDialog isOpen={true} onClose={mockOnClose} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Tokens found (2)')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText('Select all'));
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).toBeChecked();
+  });
+
+  it('should import selected tokens on Continue click', async () => {
+    render(<ImportTokensDialog isOpen={true} onClose={mockOnClose} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('TKB (TokenB)')).toBeInTheDocument();
+    });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    await userEvent.click(checkboxes[0]);
+    await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => {
+      expect(mockRegisterTokensBatch).toHaveBeenCalledOnce();
+      expect(screen.getByText('Tokens imported successfully!')).toBeInTheDocument();
+    });
+  });
+
+  it('should show error when import fails', async () => {
+    mockRegisterTokensBatch.mockResolvedValue({ registered: [], errors: [{ configString: 'x', error: 'Registration failed' }] });
+
+    render(<ImportTokensDialog isOpen={true} onClose={mockOnClose} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('TKB (TokenB)')).toBeInTheDocument();
+    });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    await userEvent.click(checkboxes[0]);
+    await userEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed/i)).toBeInTheDocument();
+    });
+  });
+
+  it('should have explorer links for each token', async () => {
+    render(<ImportTokensDialog isOpen={true} onClose={mockOnClose} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Tokens found (2)')).toBeInTheDocument();
+    });
+
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute('href', expect.stringContaining('token_detail/token-b-uid'));
+    expect(links[1]).toHaveAttribute('href', expect.stringContaining('token_detail/token-c-uid'));
+  });
+});

--- a/packages/web-wallet/src/components/__tests__/ImportTokensDialog.test.tsx
+++ b/packages/web-wallet/src/components/__tests__/ImportTokensDialog.test.tsx
@@ -180,7 +180,7 @@ describe('ImportTokensDialog', () => {
     });
   });
 
-  it('should show error on confirm step when import fails', async () => {
+  it('should show error and return to select step when import fails', async () => {
     mockRegisterTokensBatch.mockResolvedValue({ registered: [], errors: [{ configString: 'x', error: 'Registration failed' }] });
 
     render(<ImportTokensDialog isOpen={true} onClose={mockOnClose} />);
@@ -199,8 +199,10 @@ describe('ImportTokensDialog', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Import tokens' }));
 
+    // Should go back to select step with error message
     await waitFor(() => {
       expect(screen.getByText(/failed/i)).toBeInTheDocument();
+      expect(screen.getByText('Tokens found (2)')).toBeInTheDocument();
     });
   });
 

--- a/packages/web-wallet/src/components/__tests__/NewTokensBanner.test.tsx
+++ b/packages/web-wallet/src/components/__tests__/NewTokensBanner.test.tsx
@@ -55,10 +55,7 @@ describe('NewTokensBanner', () => {
       />
     );
 
-    // Find the dismiss button (the one with X icon)
-    const buttons = screen.getAllByRole('button');
-    const dismissButton = buttons.find(btn => btn !== screen.getByText('Import tokens.'));
-    await userEvent.click(dismissButton!);
+    await userEvent.click(screen.getByRole('button', { name: /dismiss/i }));
 
     expect(mockOnDismiss).toHaveBeenCalledOnce();
   });

--- a/packages/web-wallet/src/components/__tests__/NewTokensBanner.test.tsx
+++ b/packages/web-wallet/src/components/__tests__/NewTokensBanner.test.tsx
@@ -7,56 +7,37 @@ describe('NewTokensBanner', () => {
   const mockOnImportClick = vi.fn();
   const mockOnDismiss = vi.fn();
 
-  it('should not render when tokenCount is 0', () => {
-    render(
-      <NewTokensBanner
-        tokenCount={0}
-        onImportClick={mockOnImportClick}
-        onDismiss={mockOnDismiss}
-      />
-    );
+  const defaultProps = {
+    tokenCount: 3,
+    isSingleAddress: true,
+    onImportClick: mockOnImportClick,
+    onDismiss: mockOnDismiss,
+  };
 
+  it('should not render when tokenCount is 0', () => {
+    render(<NewTokensBanner {...defaultProps} tokenCount={0} />);
     expect(screen.queryByText('New tokens')).not.toBeInTheDocument();
   });
 
-  it('should render when tokenCount is greater than 0', () => {
-    render(
-      <NewTokensBanner
-        tokenCount={3}
-        onImportClick={mockOnImportClick}
-        onDismiss={mockOnDismiss}
-      />
-    );
+  it('should render with singular "address" for single address mode', () => {
+    render(<NewTokensBanner {...defaultProps} isSingleAddress={true} />);
+    expect(screen.getByText(/linked to your address that/)).toBeInTheDocument();
+  });
 
-    expect(screen.getByText('New tokens')).toBeInTheDocument();
-    expect(screen.getByText(/We found tokens linked to your address/)).toBeInTheDocument();
-    expect(screen.getByText('Import tokens.')).toBeInTheDocument();
+  it('should render with plural "addresses" for multi-address mode', () => {
+    render(<NewTokensBanner {...defaultProps} isSingleAddress={false} />);
+    expect(screen.getByText(/linked to your addresses that/)).toBeInTheDocument();
   });
 
   it('should call onImportClick when Import tokens link is clicked', async () => {
-    render(
-      <NewTokensBanner
-        tokenCount={2}
-        onImportClick={mockOnImportClick}
-        onDismiss={mockOnDismiss}
-      />
-    );
-
+    render(<NewTokensBanner {...defaultProps} />);
     await userEvent.click(screen.getByText('Import tokens.'));
     expect(mockOnImportClick).toHaveBeenCalledOnce();
   });
 
   it('should call onDismiss when X button is clicked', async () => {
-    render(
-      <NewTokensBanner
-        tokenCount={2}
-        onImportClick={mockOnImportClick}
-        onDismiss={mockOnDismiss}
-      />
-    );
-
+    render(<NewTokensBanner {...defaultProps} />);
     await userEvent.click(screen.getByRole('button', { name: /dismiss/i }));
-
     expect(mockOnDismiss).toHaveBeenCalledOnce();
   });
 });

--- a/packages/web-wallet/src/components/__tests__/NewTokensBanner.test.tsx
+++ b/packages/web-wallet/src/components/__tests__/NewTokensBanner.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NewTokensBanner from '../NewTokensBanner';
+
+describe('NewTokensBanner', () => {
+  const mockOnImportClick = vi.fn();
+  const mockOnDismiss = vi.fn();
+
+  it('should not render when tokenCount is 0', () => {
+    render(
+      <NewTokensBanner
+        tokenCount={0}
+        onImportClick={mockOnImportClick}
+        onDismiss={mockOnDismiss}
+      />
+    );
+
+    expect(screen.queryByText('New tokens')).not.toBeInTheDocument();
+  });
+
+  it('should render when tokenCount is greater than 0', () => {
+    render(
+      <NewTokensBanner
+        tokenCount={3}
+        onImportClick={mockOnImportClick}
+        onDismiss={mockOnDismiss}
+      />
+    );
+
+    expect(screen.getByText('New tokens')).toBeInTheDocument();
+    expect(screen.getByText(/We found tokens linked to your address/)).toBeInTheDocument();
+    expect(screen.getByText('Import tokens.')).toBeInTheDocument();
+  });
+
+  it('should call onImportClick when Import tokens link is clicked', async () => {
+    render(
+      <NewTokensBanner
+        tokenCount={2}
+        onImportClick={mockOnImportClick}
+        onDismiss={mockOnDismiss}
+      />
+    );
+
+    await userEvent.click(screen.getByText('Import tokens.'));
+    expect(mockOnImportClick).toHaveBeenCalledOnce();
+  });
+
+  it('should call onDismiss when X button is clicked', async () => {
+    render(
+      <NewTokensBanner
+        tokenCount={2}
+        onImportClick={mockOnImportClick}
+        onDismiss={mockOnDismiss}
+      />
+    );
+
+    // Find the dismiss button (the one with X icon)
+    const buttons = screen.getAllByRole('button');
+    const dismissButton = buttons.find(btn => btn !== screen.getByText('Import tokens.'));
+    await userEvent.click(dismissButton!);
+
+    expect(mockOnDismiss).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/web-wallet/src/contexts/WalletContext.tsx
+++ b/packages/web-wallet/src/contexts/WalletContext.tsx
@@ -320,6 +320,12 @@ export interface WalletContextType extends WalletState {
   registerToken: (configString: string) => Promise<void>;
 
   /**
+   * Register multiple tokens in batch. Adds all tokens to the list immediately,
+   * then refreshes balances once at the end.
+   */
+  registerTokensBatch: (configStrings: string[]) => Promise<{ registered: Array<{ uid: string; symbol: string }>; errors: Array<{ configString: string; error: string }> }>;
+
+  /**
    * Removes a custom token from the wallet.
    *
    * Unregisters a previously registered token, removing it from:
@@ -562,6 +568,14 @@ export function WalletProvider({ children }: WalletProviderProps) {
     await balance.refreshBalance();
   };
 
+  const registerTokensBatch = async (configStrings: string[]) => {
+    // Synchronous — saves to storage + updates state immediately (no network calls)
+    const result = tokenState.registerTokensBatch(configStrings);
+    // Single balance refresh after all tokens are added to the list
+    balance.refreshBalance();
+    return result;
+  };
+
   const unregisterToken = async (tokenUid: string) => {
     await tokenState.unregisterToken(tokenUid);
     // Balance refresh will use registeredTokensRef which is already updated
@@ -655,6 +669,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
 
     // Token methods - directly from tokenState (no sync needed!)
     registerToken,
+    registerTokensBatch,
     unregisterToken,
     refreshTokenBalances: balance.refreshBalance,
     setSelectedTokenFilter: tokenState.setSelectedTokenFilter,

--- a/packages/web-wallet/src/contexts/WalletContext.tsx
+++ b/packages/web-wallet/src/contexts/WalletContext.tsx
@@ -572,7 +572,7 @@ export function WalletProvider({ children }: WalletProviderProps) {
     // Synchronous — saves to storage + updates state immediately (no network calls)
     const result = tokenState.registerTokensBatch(configStrings);
     // Single balance refresh after all tokens are added to the list
-    balance.refreshBalance();
+    await balance.refreshBalance();
     return result;
   };
 

--- a/packages/web-wallet/src/contexts/hooks/useTokenState.ts
+++ b/packages/web-wallet/src/contexts/hooks/useTokenState.ts
@@ -110,8 +110,8 @@ export function useTokenState(options: UseTokenStateOptions) {
 
   /**
    * Register multiple tokens in batch — saves to storage and adds to state immediately.
-   * Skips NFT detection and balance fetching. Caller should refresh balances after.
-   * This is synchronous per-token (no network calls), so it's fast.
+   * Skips NFT detection and balance fetching for new tokens.
+   * Caller should refresh balances and trigger NFT detection separately after.
    */
   const registerTokensBatch = useCallback((configStrings: string[]) => {
     if (!isConnected) {

--- a/packages/web-wallet/src/contexts/hooks/useTokenState.ts
+++ b/packages/web-wallet/src/contexts/hooks/useTokenState.ts
@@ -109,6 +109,56 @@ export function useTokenState(options: UseTokenStateOptions) {
   }, [isConnected, network]);
 
   /**
+   * Register multiple tokens in batch — saves to storage and adds to state immediately.
+   * Skips NFT detection and balance fetching. Caller should refresh balances after.
+   * This is synchronous per-token (no network calls), so it's fast.
+   */
+  const registerTokensBatch = useCallback((configStrings: string[]) => {
+    if (!isConnected) {
+      throw new Error('Wallet not connected');
+    }
+
+    const genesisHash = '';
+    const newTokenInfos: TokenInfo[] = [];
+    const errors: Array<{ configString: string; error: string }> = [];
+
+    for (const configString of configStrings) {
+      try {
+        const tokenInfo = tokenRegistryService.registerTokenFast(
+          configString,
+          network,
+          genesisHash
+        );
+        newTokenInfos.push(tokenInfo);
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : 'Unknown error';
+        errors.push({ configString, error: msg });
+        log.error(`Failed to register token (${configString}):`, error);
+      }
+    }
+
+    if (newTokenInfos.length > 0) {
+      const currentTokens = registeredTokensRef.current;
+      let updatedTokens = [...currentTokens];
+
+      for (const tokenInfo of newTokenInfos) {
+        const existingIndex = updatedTokens.findIndex(t => t.uid === tokenInfo.uid);
+        if (existingIndex >= 0) {
+          updatedTokens[existingIndex] = tokenInfo;
+        } else {
+          updatedTokens = [...updatedTokens, tokenInfo];
+        }
+      }
+
+      registeredTokensRef.current = updatedTokens;
+      setRegisteredTokens(updatedTokens);
+      log.debug(`Batch registered ${newTokenInfos.length} tokens`);
+    }
+
+    return { registered: newTokenInfos, errors };
+  }, [isConnected, network]);
+
+  /**
    * Unregister a token
    */
   const unregisterToken = useCallback(async (tokenUid: string) => {
@@ -164,6 +214,7 @@ export function useTokenState(options: UseTokenStateOptions) {
 
     // Operations
     registerToken,
+    registerTokensBatch,
     unregisterToken,
     loadTokensForNetwork,
     getTokenInfo,

--- a/packages/web-wallet/src/hooks/useTokenDiscovery.ts
+++ b/packages/web-wallet/src/hooks/useTokenDiscovery.ts
@@ -77,11 +77,15 @@ export function useTokenDiscovery({
     }
   }, [isConnected, network, dismissKey]);
 
-  // Run discovery after wallet connects
+  // Run discovery after wallet connects, reset on disconnect
   useEffect(() => {
     if (isConnected && !hasDiscoveredRef.current) {
       hasDiscoveredRef.current = true;
       runDiscovery();
+    }
+    if (!isConnected) {
+      hasDiscoveredRef.current = false;
+      setDiscoveredTokenUids([]);
     }
   }, [isConnected, runDiscovery]);
 

--- a/packages/web-wallet/src/hooks/useTokenDiscovery.ts
+++ b/packages/web-wallet/src/hooks/useTokenDiscovery.ts
@@ -1,0 +1,100 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { tokenDiscoveryService } from '../services/TokenDiscoveryService';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('useTokenDiscovery');
+
+const DISMISS_KEY_PREFIX = 'hathor_wallet_token_discovery_dismissed_';
+
+interface UseTokenDiscoveryOptions {
+  isConnected: boolean;
+  network: string;
+}
+
+interface UseTokenDiscoveryResult {
+  /** UIDs of unregistered tokens found on the wallet */
+  discoveredTokenUids: string[];
+  isDiscovering: boolean;
+  isDismissed: boolean;
+  dismissBanner: () => void;
+  refreshDiscovery: () => Promise<void>;
+}
+
+/**
+ * Hook for discovering unregistered token UIDs on the wallet.
+ * Only fetches the list of token UIDs (single fast request).
+ * Balance/name fetching is deferred to the ImportTokensDialog.
+ */
+export function useTokenDiscovery({
+  isConnected,
+  network,
+}: UseTokenDiscoveryOptions): UseTokenDiscoveryResult {
+  const [discoveredTokenUids, setDiscoveredTokenUids] = useState<string[]>([]);
+  const [isDiscovering, setIsDiscovering] = useState(false);
+  const [isDismissed, setIsDismissed] = useState(false);
+
+  const hasDiscoveredRef = useRef(false);
+  const prevNetworkRef = useRef(network);
+
+  const dismissKey = `${DISMISS_KEY_PREFIX}${network}`;
+
+  // Check sessionStorage for dismiss state on mount/network change
+  useEffect(() => {
+    try {
+      const dismissed = sessionStorage.getItem(dismissKey);
+      setIsDismissed(dismissed === 'true');
+    } catch {
+      setIsDismissed(false);
+    }
+  }, [dismissKey]);
+
+  // Reset discovery on network change
+  useEffect(() => {
+    if (prevNetworkRef.current !== network) {
+      prevNetworkRef.current = network;
+      hasDiscoveredRef.current = false;
+      setDiscoveredTokenUids([]);
+    }
+  }, [network]);
+
+  const runDiscovery = useCallback(async () => {
+    if (!isConnected) return;
+
+    setIsDiscovering(true);
+    try {
+      const uids = await tokenDiscoveryService.discoverTokenUids(network);
+      setDiscoveredTokenUids(uids);
+
+      if (uids.length === 0) {
+        try { sessionStorage.removeItem(dismissKey); } catch { /* ignore */ }
+        setIsDismissed(false);
+      }
+    } catch (error) {
+      log.error('Token discovery failed:', error);
+      setDiscoveredTokenUids([]);
+    } finally {
+      setIsDiscovering(false);
+    }
+  }, [isConnected, network, dismissKey]);
+
+  // Run discovery after wallet connects
+  useEffect(() => {
+    if (isConnected && !hasDiscoveredRef.current) {
+      hasDiscoveredRef.current = true;
+      runDiscovery();
+    }
+  }, [isConnected, runDiscovery]);
+
+  const dismissBanner = useCallback(() => {
+    setIsDismissed(true);
+    try { sessionStorage.setItem(dismissKey, 'true'); } catch { /* ignore */ }
+  }, [dismissKey]);
+
+  return {
+    discoveredTokenUids,
+    isDiscovering,
+    isDismissed,
+    dismissBanner,
+    refreshDiscovery: runDiscovery,
+  };
+}

--- a/packages/web-wallet/src/hooks/useTokenDiscovery.ts
+++ b/packages/web-wallet/src/hooks/useTokenDiscovery.ts
@@ -9,6 +9,8 @@ const DISMISS_KEY_PREFIX = 'hathor_wallet_token_discovery_dismissed_';
 interface UseTokenDiscoveryOptions {
   isConnected: boolean;
   network: string;
+  /** Pass newTransaction from WalletContext to re-run discovery on new tx */
+  newTransaction?: unknown;
 }
 
 interface UseTokenDiscoveryResult {
@@ -28,6 +30,7 @@ interface UseTokenDiscoveryResult {
 export function useTokenDiscovery({
   isConnected,
   network,
+  newTransaction,
 }: UseTokenDiscoveryOptions): UseTokenDiscoveryResult {
   const [discoveredTokenUids, setDiscoveredTokenUids] = useState<string[]>([]);
   const [isDiscovering, setIsDiscovering] = useState(false);
@@ -88,6 +91,13 @@ export function useTokenDiscovery({
       setDiscoveredTokenUids([]);
     }
   }, [isConnected, runDiscovery]);
+
+  // Re-run discovery when a new transaction arrives (might contain a new token)
+  useEffect(() => {
+    if (isConnected && newTransaction && hasDiscoveredRef.current) {
+      runDiscovery();
+    }
+  }, [newTransaction]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const dismissBanner = useCallback(() => {
     setIsDismissed(true);

--- a/packages/web-wallet/src/services/ReadOnlyWalletWrapper.ts
+++ b/packages/web-wallet/src/services/ReadOnlyWalletWrapper.ts
@@ -1,7 +1,7 @@
 import { HathorWalletServiceWallet, Network, config } from '@hathor/wallet-lib';
 import type { GetHistoryObject, AddressInfoObject } from '@hathor/wallet-lib/lib/wallet/types';
 import { NETWORKS, WALLET_SERVICE_URLS, WALLET_SERVICE_WS_URLS, TOKEN_IDS } from '../constants';
-import type { WalletBalance, TransactionHistoryItem } from '../types/wallet';
+import type { WalletBalance, TransactionHistoryItem, TokenBalanceInfo } from '../types/wallet';
 import { toBigInt } from '../utils/hathor';
 import { createLogger } from '../utils/logger';
 import { ERROR_PATTERNS } from '../errors/WalletConnectionErrors';
@@ -186,6 +186,46 @@ export class ReadOnlyWalletWrapper {
   }
 
   /**
+   * Get token balances with full token info (id, name, symbol).
+   * Unlike getBalance(), this preserves the token name and symbol from the API response.
+   * Used by token discovery to find unregistered tokens.
+   *
+   * @param tokenId - Optional token ID to fetch balance for a specific token.
+   *                  If null/undefined, fetches all known token balances.
+   */
+  async getAllTokenBalances(tokenId?: string): Promise<TokenBalanceInfo[]> {
+    if (!this.wallet) {
+      throw new Error('Wallet not initialized');
+    }
+
+    this.ensureConfigUrls();
+
+    try {
+      const balance = await this.wallet.getBalance(tokenId ?? null);
+      const result: TokenBalanceInfo[] = [];
+
+      if (Array.isArray(balance)) {
+        for (const item of balance) {
+          result.push({
+            uid: item.token.id,
+            name: item.token.name,
+            symbol: item.token.symbol,
+            balance: {
+              available: item.balance.unlocked != null ? toBigInt(item.balance.unlocked) : 0n,
+              locked: item.balance.locked != null ? toBigInt(item.balance.locked) : 0n,
+            },
+          });
+        }
+      }
+
+      return result;
+    } catch (error) {
+      log.error('Failed to get all token balances:', error);
+      throw error;
+    }
+  }
+
+  /**
    * Get transaction history
    */
   async getTransactionHistory(count: number = 10, skip: number = 0, tokenId: string = TOKEN_IDS.HTR): Promise<TransactionHistoryItem[]> {
@@ -299,17 +339,19 @@ export class ReadOnlyWalletWrapper {
   }
 
   /**
-   * Get tokens in the wallet
+   * Get all token UIDs that the wallet has interacted with.
+   * Calls wallet-service GET /wallet/tokens.
    */
-  async getTokens(): Promise<Array<Record<string, unknown>>> {
+  async getTokens(): Promise<string[]> {
     if (!this.wallet) {
       throw new Error('Wallet not initialized');
     }
 
+    this.ensureConfigUrls();
+
     try {
       const tokens = await this.wallet.getTokens();
-      // wallet-lib returns string[] but we need Record<string, unknown>[]
-      return tokens as unknown as Array<Record<string, unknown>>;
+      return tokens as string[];
     } catch (error) {
       log.error('Failed to get tokens:', error);
       throw error;

--- a/packages/web-wallet/src/services/ReadOnlyWalletWrapper.ts
+++ b/packages/web-wallet/src/services/ReadOnlyWalletWrapper.ts
@@ -210,6 +210,7 @@ export class ReadOnlyWalletWrapper {
             uid: item.token.id,
             name: item.token.name,
             symbol: item.token.symbol,
+            version: item.token.version,
             balance: {
               available: item.balance.unlocked != null ? toBigInt(item.balance.unlocked) : 0n,
               locked: item.balance.locked != null ? toBigInt(item.balance.locked) : 0n,

--- a/packages/web-wallet/src/services/TokenDiscoveryService.ts
+++ b/packages/web-wallet/src/services/TokenDiscoveryService.ts
@@ -37,8 +37,8 @@ export class TokenDiscoveryService {
       const allTokenUids = await readOnlyWalletWrapper.getTokens();
       log.debug(`Wallet has ${allTokenUids.length} total tokens`);
 
-      // Read from storage directly — always up-to-date, no React state race condition
       const genesisHash = '';
+      // Read from storage directly — always up-to-date, no React state race condition
       const storedTokens = registeredTokenStorageService.loadTokenData(network, genesisHash);
       const registeredUids = new Set<string>(Object.keys(storedTokens));
       registeredUids.add(TOKEN_IDS.HTR);

--- a/packages/web-wallet/src/services/TokenDiscoveryService.ts
+++ b/packages/web-wallet/src/services/TokenDiscoveryService.ts
@@ -2,17 +2,12 @@ import { readOnlyWalletWrapper } from './ReadOnlyWalletWrapper';
 import { registeredTokenStorageService } from './RegisteredTokenStorageService';
 import { TOKEN_IDS } from '../constants';
 import { createLogger } from '../utils/logger';
+import type { TokenBalanceInfo } from '../types/wallet';
 
 const log = createLogger('TokenDiscoveryService');
 
-export interface DiscoveredToken {
+export interface DiscoveredToken extends Partial<TokenBalanceInfo> {
   uid: string;
-  name?: string;
-  symbol?: string;
-  balance?: {
-    available: bigint;
-    locked: bigint;
-  };
   isLoadingBalance?: boolean;
 }
 

--- a/packages/web-wallet/src/services/TokenDiscoveryService.ts
+++ b/packages/web-wallet/src/services/TokenDiscoveryService.ts
@@ -1,0 +1,84 @@
+import { readOnlyWalletWrapper } from './ReadOnlyWalletWrapper';
+import { registeredTokenStorageService } from './RegisteredTokenStorageService';
+import { TOKEN_IDS } from '../constants';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('TokenDiscoveryService');
+
+export interface DiscoveredToken {
+  uid: string;
+  name?: string;
+  symbol?: string;
+  balance?: {
+    available: bigint;
+    locked: bigint;
+  };
+  isLoadingBalance?: boolean;
+}
+
+/**
+ * Service for discovering tokens that exist on the user's wallet
+ * but are not yet registered in the web wallet.
+ *
+ * Discovery is split into two phases:
+ * 1. Fast: getTokens() returns all token UIDs — used for banner + list
+ * 2. Lazy: getBalance(tokenId) fetched on demand with throttling
+ */
+export class TokenDiscoveryService {
+  /**
+   * Discover unregistered token UIDs on the wallet (fast, single request).
+   * Returns UIDs only — no balance or name/symbol info.
+   *
+   * Reads registered tokens from storage (not React state) to avoid race
+   * conditions where state hasn't been populated yet.
+   */
+  async discoverTokenUids(network: string): Promise<string[]> {
+    if (!readOnlyWalletWrapper.isReady()) {
+      log.warn('Wallet not ready, skipping token discovery');
+      return [];
+    }
+
+    try {
+      const allTokenUids = await readOnlyWalletWrapper.getTokens();
+      log.debug(`Wallet has ${allTokenUids.length} total tokens`);
+
+      // Read from storage directly — always up-to-date, no React state race condition
+      const genesisHash = '';
+      const storedTokens = registeredTokenStorageService.loadTokenData(network, genesisHash);
+      const registeredUids = new Set<string>(Object.keys(storedTokens));
+      registeredUids.add(TOKEN_IDS.HTR);
+
+      const unregisteredUids = allTokenUids.filter(uid => !registeredUids.has(uid));
+      log.debug(`Found ${unregisteredUids.length} unregistered token UIDs`);
+
+      return unregisteredUids;
+    } catch (error) {
+      log.error('Failed to discover tokens:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Fetch balance + name/symbol for a single token.
+   */
+  async fetchTokenDetails(uid: string): Promise<DiscoveredToken | null> {
+    try {
+      const balanceInfos = await readOnlyWalletWrapper.getAllTokenBalances(uid);
+      const tokenInfo = balanceInfos.find(t => t.uid === uid);
+
+      if (!tokenInfo) return null;
+
+      return {
+        uid: tokenInfo.uid,
+        name: tokenInfo.name,
+        symbol: tokenInfo.symbol,
+        balance: tokenInfo.balance,
+      };
+    } catch (err) {
+      log.warn(`Failed to fetch details for token ${uid}:`, err);
+      return null;
+    }
+  }
+}
+
+export const tokenDiscoveryService = new TokenDiscoveryService();

--- a/packages/web-wallet/src/services/TokenRegistryService.ts
+++ b/packages/web-wallet/src/services/TokenRegistryService.ts
@@ -190,8 +190,9 @@ export class TokenRegistryService {
   }
 
   /**
-   * Register a token quickly — saves to storage only, skips NFT detection and balance fetch.
-   * Used for batch import where balances are loaded separately after.
+   * Register a token quickly — saves to storage only.
+   * For new tokens: skips NFT detection and balance fetch (loaded separately after).
+   * For already-registered tokens: returns existing data + metadata from storage.
    */
   registerTokenFast(
     configString: string,

--- a/packages/web-wallet/src/services/TokenRegistryService.ts
+++ b/packages/web-wallet/src/services/TokenRegistryService.ts
@@ -190,6 +190,61 @@ export class TokenRegistryService {
   }
 
   /**
+   * Register a token quickly — saves to storage only, skips NFT detection and balance fetch.
+   * Used for batch import where balances are loaded separately after.
+   */
+  registerTokenFast(
+    configString: string,
+    network: string,
+    genesisHash: string
+  ): TokenInfo {
+    const validation = this.validateConfigString(configString);
+    if (!validation.valid || !validation.parsed) {
+      throw new Error(validation.error || 'Invalid configuration string');
+    }
+
+    const { uid, name, symbol } = validation.parsed;
+
+    if (uid === TOKEN_IDS.HTR) {
+      throw new Error('Cannot register the native HTR token');
+    }
+
+    // Skip if already registered
+    if (registeredTokenStorageService.isTokenRegistered(network, genesisHash, uid)) {
+      const existing = registeredTokenStorageService.getTokenData(network, genesisHash, uid);
+      const metadata = registeredTokenStorageService.getTokenMetadata(network, genesisHash, uid);
+      return {
+        ...(existing || { uid, name, symbol, configString }),
+        isNFT: metadata?.isNFT ?? false,
+        registeredAt: metadata?.registeredAt,
+        metadata: metadata?.metadata,
+        balance: { available: 0n, locked: 0n },
+      };
+    }
+
+    const tokenData: TokenData = { uid, name, symbol, configString };
+    const tokenMetadata: TokenMetadata = {
+      uid,
+      isNFT: false,
+      registeredAt: Date.now(),
+    };
+
+    const dataSaved = registeredTokenStorageService.addTokenData(network, genesisHash, tokenData);
+    if (!dataSaved) {
+      throw new Error('Failed to save token data to browser storage.');
+    }
+
+    registeredTokenStorageService.updateTokenMetadata(network, genesisHash, uid, tokenMetadata);
+    this.tokenCache.set(uid, tokenMetadata);
+
+    return {
+      ...tokenData,
+      ...tokenMetadata,
+      balance: { available: 0n, locked: 0n },
+    };
+  }
+
+  /**
    * Unregister a token (removes both data and metadata)
    */
   unregisterToken(tokenUid: string, network: string, genesisHash: string): void {

--- a/packages/web-wallet/src/services/TokenRegistryService.ts
+++ b/packages/web-wallet/src/services/TokenRegistryService.ts
@@ -234,8 +234,10 @@ export class TokenRegistryService {
       throw new Error('Failed to save token data to browser storage.');
     }
 
-    registeredTokenStorageService.updateTokenMetadata(network, genesisHash, uid, tokenMetadata);
-    this.tokenCache.set(uid, tokenMetadata);
+    const metadataSaved = registeredTokenStorageService.updateTokenMetadata(network, genesisHash, uid, tokenMetadata);
+    if (metadataSaved) {
+      this.tokenCache.set(uid, tokenMetadata);
+    }
 
     return {
       ...tokenData,

--- a/packages/web-wallet/src/services/__tests__/TokenDiscoveryService.test.ts
+++ b/packages/web-wallet/src/services/__tests__/TokenDiscoveryService.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { mockGetAllTokenBalances, mockGetTokens, mockIsReady, mockLoadTokenData } = vi.hoisted(() => ({
+  mockGetAllTokenBalances: vi.fn(),
+  mockGetTokens: vi.fn(),
+  mockIsReady: vi.fn(),
+  mockLoadTokenData: vi.fn(),
+}));
+
+vi.mock('../ReadOnlyWalletWrapper', () => ({
+  readOnlyWalletWrapper: {
+    getAllTokenBalances: mockGetAllTokenBalances,
+    getTokens: mockGetTokens,
+    isReady: mockIsReady,
+  },
+}));
+
+vi.mock('../RegisteredTokenStorageService', () => ({
+  registeredTokenStorageService: {
+    loadTokenData: mockLoadTokenData,
+  },
+}));
+
+vi.mock('../../constants', () => ({
+  TOKEN_IDS: { HTR: '00' },
+}));
+
+vi.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import { TokenDiscoveryService } from '../TokenDiscoveryService';
+
+describe('TokenDiscoveryService', () => {
+  let service: TokenDiscoveryService;
+
+  const network = 'mainnet';
+
+  // Simulates tokens stored in localStorage (keyed by uid)
+  const storedTokens: Record<string, { uid: string; name: string; symbol: string }> = {
+    'token-a-uid': { uid: 'token-a-uid', name: 'TokenA', symbol: 'TKA' },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new TokenDiscoveryService();
+    mockIsReady.mockReturnValue(true);
+    mockLoadTokenData.mockReturnValue(storedTokens);
+  });
+
+  describe('discoverTokenUids', () => {
+    it('should return unregistered token UIDs', async () => {
+      mockGetTokens.mockResolvedValue(['00', 'token-a-uid', 'token-b-uid', 'token-c-uid']);
+
+      const uids = await service.discoverTokenUids(network);
+
+      expect(uids).toEqual(['token-b-uid', 'token-c-uid']);
+      expect(mockGetTokens).toHaveBeenCalledOnce();
+      expect(mockLoadTokenData).toHaveBeenCalledWith(network, '');
+    });
+
+    it('should exclude HTR even if not in stored tokens', async () => {
+      mockLoadTokenData.mockReturnValue({});
+      mockGetTokens.mockResolvedValue(['00']);
+
+      const uids = await service.discoverTokenUids(network);
+
+      expect(uids).toHaveLength(0);
+    });
+
+    it('should return empty array when wallet is not ready', async () => {
+      mockIsReady.mockReturnValue(false);
+
+      const uids = await service.discoverTokenUids(network);
+
+      expect(uids).toHaveLength(0);
+      expect(mockGetTokens).not.toHaveBeenCalled();
+    });
+
+    it('should throw when getTokens fails', async () => {
+      mockGetTokens.mockRejectedValue(new Error('Network error'));
+
+      await expect(service.discoverTokenUids(network)).rejects.toThrow('Network error');
+    });
+
+    it('should return empty array when all tokens are already registered', async () => {
+      mockGetTokens.mockResolvedValue(['00', 'token-a-uid']);
+
+      const uids = await service.discoverTokenUids(network);
+
+      expect(uids).toHaveLength(0);
+    });
+  });
+
+  describe('fetchTokenDetails', () => {
+    it('should return token details with balance', async () => {
+      mockGetAllTokenBalances.mockResolvedValue([
+        { uid: 'token-b-uid', name: 'TokenB', symbol: 'TKB', balance: { available: 200n, locked: 0n } },
+      ]);
+
+      const detail = await service.fetchTokenDetails('token-b-uid');
+
+      expect(detail).toEqual({
+        uid: 'token-b-uid',
+        name: 'TokenB',
+        symbol: 'TKB',
+        balance: { available: 200n, locked: 0n },
+      });
+      expect(mockGetAllTokenBalances).toHaveBeenCalledWith('token-b-uid');
+    });
+
+    it('should return null when token not found in response', async () => {
+      mockGetAllTokenBalances.mockResolvedValue([]);
+
+      const detail = await service.fetchTokenDetails('nonexistent');
+
+      expect(detail).toBeNull();
+    });
+
+    it('should return null on error', async () => {
+      mockGetAllTokenBalances.mockRejectedValue(new Error('Fetch failed'));
+
+      const detail = await service.fetchTokenDetails('token-b-uid');
+
+      expect(detail).toBeNull();
+    });
+  });
+});

--- a/packages/web-wallet/src/types/wallet.ts
+++ b/packages/web-wallet/src/types/wallet.ts
@@ -14,6 +14,19 @@ export interface WalletBalance {
  */
 export type WalletBalanceMap = Map<string, WalletBalance>;
 
+/**
+ * Token balance info including name and symbol, used for token discovery
+ */
+export interface TokenBalanceInfo {
+  uid: string;
+  name: string;
+  symbol: string;
+  balance: {
+    available: bigint;
+    locked: bigint;
+  };
+}
+
 export interface TransactionHistoryItem {
   tx_id: string;
   timestamp: number;

--- a/packages/web-wallet/src/types/wallet.ts
+++ b/packages/web-wallet/src/types/wallet.ts
@@ -21,6 +21,7 @@ export interface TokenBalanceInfo {
   uid: string;
   name: string;
   symbol: string;
+  version?: number;
   balance: {
     available: bigint;
     locked: bigint;


### PR DESCRIPTION


https://github.com/user-attachments/assets/cd7c9ac8-d175-467a-959b-f0fc00708058




### Motivation

Users with tokens on their address that aren't registered in the web wallet currently need to manually register each one via configuration string. This adds auto-detection and one-click batch import.

### Acceptance Criteria

- [ ] Green banner appears when unregistered tokens are detected (single `/wallet/tokens` request on connection)
- [ ] Banner is dismissable (per session) and disappears after successful import
- [ ] "Import Tokens" dialog lets users select and import multiple tokens at once
- [ ] Token details (name, symbol, balance) lazy-load with throttled requests (2 per 500ms, scroll-based)
- [ ] Batch import is instant (no per-token NFT detection or balance fetch) — balances refresh once after
- [ ] No race condition: discovery reads registered tokens from localStorage, not React state
- [ ] "Import Tokens" menu item in hamburger menu when discoverable tokens exist
- [ ] 23 new unit tests, no new dependencies

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet discovers new tokens for your address and shows a dismissible banner with an inline “Import tokens” action; discovery persists per network and can be refreshed.
  * New import dialog to review, select (including “Select all”), preview discovered tokens, and import with progress, success/error feedback plus “See all tokens”.
  * “Import Tokens” entry added to the header; batch import is supported and refreshes balances after completion.
* **Tests**
  * Added UI and service tests covering discovery, import flows, and error/success scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->