### PR TITLE
feat(web-wallet): gate fee-based tokens behind a per-network Unleash flag

### DIFF
--- a/packages/web-wallet/src/App.tsx
+++ b/packages/web-wallet/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, useNavigate, useParams } from 'react-router-dom'
 import { MetaMaskProvider } from '@hathor/snap-utils'
 import { WalletProvider } from './contexts/WalletContext'
+import { NetworkProvider } from './contexts/NetworkContext'
 import { FeatureToggleProvider, useFeatureToggle } from './contexts/FeatureToggleContext'
 import WalletHome from './components/WalletHome'
 import MaintenancePage from './components/MaintenancePage'
@@ -117,9 +118,11 @@ function App() {
   return (
     <ErrorBoundary>
       <BrowserRouter>
-        <FeatureToggleProvider>
-          <FeatureGatedWallet />
-        </FeatureToggleProvider>
+        <NetworkProvider>
+          <FeatureToggleProvider>
+            <FeatureGatedWallet />
+          </FeatureToggleProvider>
+        </NetworkProvider>
       </BrowserRouter>
     </ErrorBoundary>
   )

--- a/packages/web-wallet/src/components/CreateTokenDialog.tsx
+++ b/packages/web-wallet/src/components/CreateTokenDialog.tsx
@@ -4,6 +4,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useWallet } from '../contexts/WalletContext';
+import { useFeatureToggle } from '../contexts/FeatureToggleContext';
 import { useInvokeSnap } from '@hathor/snap-utils';
 import { helpersUtils, tokensUtils, constants, TokenVersion } from '@hathor/wallet-lib';
 import { formatAmount, amountToCents } from '../utils/hathor';
@@ -104,6 +105,7 @@ const CreateTokenDialog: React.FC<CreateTokenDialogProps> = ({ isOpen, onClose }
   const activeRequestRef = useRef(0);
 
   const { registerToken, balances, addressMode } = useWallet();
+  const { isFeeTokensEnabled } = useFeatureToggle();
   const invokeSnap = useInvokeSnap();
   const { toast } = useToast();
 
@@ -138,6 +140,11 @@ const CreateTokenDialog: React.FC<CreateTokenDialogProps> = ({ isOpen, onClose }
   const nftData = watch('nftData');
   const tokenType = watch('tokenType');
 
+  // Fee-based tokens require both the Unleash flag and a non-NFT 'fee' selection.
+  // When the flag is off the Token Type dropdown is hidden, so tokenType stays
+  // 'deposit' and the token behaves as a regular deposit token.
+  const isFeeBasedToken = isFeeTokensEnabled && !isNFT && tokenType === 'fee';
+
   // When toggling to NFT mode, strip any decimal portion from the amount and
   // snap the token type to 'deposit' (NFTs are always deposit-based; the
   // submit handler already forces this, but the UI should reflect it too).
@@ -161,7 +168,7 @@ const CreateTokenDialog: React.FC<CreateTokenDialogProps> = ({ isOpen, onClose }
       if (!amount || amount === '0') return 0n;
 
       // Fee tokens don't require an HTR deposit
-      if (!isNFT && tokenType === 'fee') return 0n;
+      if (isFeeBasedToken) return 0n;
 
       let amountInBaseUnits: bigint;
       if (isNFT) {
@@ -186,7 +193,7 @@ const CreateTokenDialog: React.FC<CreateTokenDialogProps> = ({ isOpen, onClose }
     } catch {
       return 0n;
     }
-  }, [amount, isNFT, nftData, tokenType]);
+  }, [amount, isNFT, nftData, isFeeBasedToken]);
 
   // Check if user has insufficient balance
   const hasInsufficientBalance = useMemo(() => {
@@ -214,8 +221,10 @@ const CreateTokenDialog: React.FC<CreateTokenDialogProps> = ({ isOpen, onClose }
         ? BigInt(data.amount)
         : amountToCents(data.amount);
 
-      // NFTs are always deposit-based; only regular tokens can be fee-based
-      const tokenVersion = data.isNFT ? 'deposit' : data.tokenType;
+      // Fee-based tokens require the Unleash flag; NFTs are always deposit-based.
+      // When the flag is off we always fall back to a deposit token.
+      const isCreatingFeeToken = isFeeTokensEnabled && !data.isNFT && data.tokenType === 'fee';
+      const tokenVersion = isCreatingFeeToken ? 'fee' : 'deposit';
 
       // Prepare RPC params matching createTokenRpcSchema
       const params = {
@@ -291,10 +300,9 @@ const CreateTokenDialog: React.FC<CreateTokenDialogProps> = ({ isOpen, onClose }
       // handles most cases. The branches below cover Create-specific overrides
       // that don't fit the generic snap error mapping.
       const errorMsg = extractErrorMessage(err, 'Failed to create token');
-      // Mirrors the version we send in the RPC payload: only regular tokens can
-      // be fee-based; NFTs are always deposit. Lets the shared mapper tailor the
-      // HTR-shortage message (deposit vs. network fee).
-      const tokenVersion = !data.isNFT && data.tokenType === 'fee'
+      // Mirrors the version we send in the RPC payload: fee-based tokens require
+      // the Unleash flag and a non-NFT 'fee' selection, otherwise it's a deposit.
+      const tokenVersion = isFeeTokensEnabled && !data.isNFT && data.tokenType === 'fee'
         ? TokenVersion.FEE
         : TokenVersion.DEPOSIT;
       const mappedMsg = getSnapErrorUserMessage(errorMsg, { tokenVersion });
@@ -581,7 +589,8 @@ const CreateTokenDialog: React.FC<CreateTokenDialogProps> = ({ isOpen, onClose }
                 </div>
               </div>
 
-              {!isNFT && (
+              {/* Token Type dropdown - only shown when fee-based tokens feature is enabled */}
+              {isFeeTokensEnabled && !isNFT && (
               <div className="flex flex-col md:flex-row md:items-center gap-2 md:gap-6">
                 <div className="flex items-center gap-2 md:w-[120px]">
                   <label className="text-sm md:text-base font-bold text-white">Token Type</label>

--- a/packages/web-wallet/src/constants.ts
+++ b/packages/web-wallet/src/constants.ts
@@ -55,6 +55,11 @@ export const DEFAULT_NETWORK = NETWORKS.MAINNET;
 export const DEFAULT_ADDRESS_INDEX = 0;
 export const DEFAULT_ADDRESS_TYPE = 'index' as const;
 
+// localStorage key for the active network. Owned by the NetworkProvider, which
+// is the single source of truth for the active network and the only place that
+// reads/writes this key.
+export const NETWORK_STORAGE_KEY = 'hathor_wallet_network';
+
 // UI Constants
 export const QR_CODE_SIZE = 200;
 export const TRANSACTION_HISTORY_LIMIT = 50;
@@ -80,10 +85,15 @@ export const UNLEASH_POLLING_INTERVAL = 15 * 1000; // 15s
 
 // Feature toggle names
 export const WEB_WALLET_MAINTENANCE_TOGGLE = 'web-wallet.maintenance';
+// Web-wallet-specific rollout flag for fee-based tokens (separate from
+// hathor-wallet-mobile's 'fee-based-tokens.rollout' so each client can be
+// rolled out independently).
+export const FEE_BASED_TOKENS_TOGGLE = 'fee-based-tokens-webwallet.rollout';
 
 // Feature toggle defaults
 // Note: Unleash Proxy only returns enabled toggles. If a toggle is disabled or
 // doesn't exist, it won't be in the response.
 export const FEATURE_TOGGLE_DEFAULTS: Record<string, boolean> = {
   [WEB_WALLET_MAINTENANCE_TOGGLE]: false, // Default: not under maintenance
+  [FEE_BASED_TOKENS_TOGGLE]: false, // Default: fee-based tokens feature disabled
 };

--- a/packages/web-wallet/src/contexts/FeatureToggleContext.tsx
+++ b/packages/web-wallet/src/contexts/FeatureToggleContext.tsx
@@ -6,10 +6,12 @@ import {
   UNLEASH_CLIENT_KEY,
   UNLEASH_POLLING_INTERVAL,
   WEB_WALLET_MAINTENANCE_TOGGLE,
+  FEE_BASED_TOKENS_TOGGLE,
   FEATURE_TOGGLE_DEFAULTS,
   STAGE,
   SKIP_FEATURE_TOGGLE,
 } from '../constants';
+import { useNetwork } from './NetworkContext';
 
 const MAX_RETRIES = 5;
 const RETRY_DELAY = 500;
@@ -32,6 +34,7 @@ function getBrowserId(): string {
 
 interface FeatureToggleContextType {
   isUnderMaintenance: boolean;
+  isFeeTokensEnabled: boolean;
   isLoading: boolean;
   featureToggles: Record<string, boolean>;
   /** Unique browser identifier used for feature toggle targeting */
@@ -65,6 +68,13 @@ export function FeatureToggleProvider({ children }: FeatureToggleProviderProps) 
   // Get or create a unique browser ID for feature toggle targeting
   const browserId = getBrowserId();
 
+  // Active Hathor network from the NetworkProvider, sent as an Unleash context
+  // property so flags can be constrained per-network (e.g. fee-based tokens are
+  // testnet-only). When it changes, the init effect below recreates the Unleash
+  // client with the new context (the client has no updateContext; the context
+  // is fixed at construction).
+  const { network } = useNetwork();
+
   useEffect(() => {
     let mounted = true;
 
@@ -87,6 +97,7 @@ export function FeatureToggleProvider({ children }: FeatureToggleProviderProps) 
             properties: {
               platform: 'web',
               stage: STAGE,
+              network,
             },
           },
         });
@@ -145,12 +156,15 @@ export function FeatureToggleProvider({ children }: FeatureToggleProviderProps) 
       // Clear the reference (unleash-client doesn't have a close method)
       unleashClientRef.current = null;
     };
-  }, []);
+    // Re-run (and recreate the client) whenever the network changes so the
+    // Unleash context reflects the active network for per-network constraints.
+  }, [network, browserId]);
 
   const isUnderMaintenance = featureToggles[WEB_WALLET_MAINTENANCE_TOGGLE] ?? FEATURE_TOGGLE_DEFAULTS[WEB_WALLET_MAINTENANCE_TOGGLE];
+  const isFeeTokensEnabled = featureToggles[FEE_BASED_TOKENS_TOGGLE] ?? FEATURE_TOGGLE_DEFAULTS[FEE_BASED_TOKENS_TOGGLE];
 
   return (
-    <FeatureToggleContext.Provider value={{ isUnderMaintenance, isLoading, featureToggles, browserId }}>
+    <FeatureToggleContext.Provider value={{ isUnderMaintenance, isFeeTokensEnabled, isLoading, featureToggles, browserId }}>
       {children}
     </FeatureToggleContext.Provider>
   );

--- a/packages/web-wallet/src/contexts/NetworkContext.tsx
+++ b/packages/web-wallet/src/contexts/NetworkContext.tsx
@@ -1,0 +1,58 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+import { DEFAULT_NETWORK, NETWORK_STORAGE_KEY } from '../constants';
+
+interface NetworkContextType {
+  /** Active Hathor network (e.g. 'mainnet', 'testnet'). */
+  network: string;
+  /** Sets the active network and persists it to localStorage. */
+  setNetwork: (network: string) => void;
+  /** Resets the network to the default and removes it from localStorage. */
+  clearNetwork: () => void;
+}
+
+const NetworkContext = createContext<NetworkContextType | null>(null);
+
+interface NetworkProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * Single source of truth for the active Hathor network.
+ *
+ * Lives above both the FeatureToggleProvider and the WalletProvider so the
+ * network can flow down to consumers via React context instead of a side
+ * channel. The wallet hooks remain the ones that decide/validate the network
+ * (via the snap), but they read and write it here. Persistence to localStorage
+ * is centralized in this provider so there is exactly one place that owns the
+ * stored value.
+ */
+export function NetworkProvider({ children }: NetworkProviderProps) {
+  const [network, setNetworkState] = useState<string>(
+    () => localStorage.getItem(NETWORK_STORAGE_KEY) || DEFAULT_NETWORK
+  );
+
+  const setNetwork = useCallback((nextNetwork: string) => {
+    setNetworkState(nextNetwork);
+    localStorage.setItem(NETWORK_STORAGE_KEY, nextNetwork);
+  }, []);
+
+  const clearNetwork = useCallback(() => {
+    setNetworkState(DEFAULT_NETWORK);
+    localStorage.removeItem(NETWORK_STORAGE_KEY);
+  }, []);
+
+  return (
+    <NetworkContext.Provider value={{ network, setNetwork, clearNetwork }}>
+      {children}
+    </NetworkContext.Provider>
+  );
+}
+
+export function useNetwork() {
+  const context = useContext(NetworkContext);
+  if (!context) {
+    throw new Error('useNetwork must be used within a NetworkProvider');
+  }
+  return context;
+}

--- a/packages/web-wallet/src/contexts/__tests__/WalletContext.test.tsx
+++ b/packages/web-wallet/src/contexts/__tests__/WalletContext.test.tsx
@@ -141,6 +141,7 @@ vi.mock('../../components/ConnectionLostModal', () => ({
 
 // Import after mocks are defined
 import { WalletProvider, useWallet } from '../WalletContext';
+import { NetworkProvider } from '../NetworkContext';
 
 // Test component to consume context
 function TestConsumer({ onContext }: { onContext?: (ctx: ReturnType<typeof useWallet>) => void }) {
@@ -185,9 +186,9 @@ describe('WalletContext', () => {
   describe('Provider', () => {
     it('should render children without crashing', () => {
       render(
-        <WalletProvider>
+        <NetworkProvider><WalletProvider>
           <div data-testid="child">Hello</div>
-        </WalletProvider>
+        </WalletProvider></NetworkProvider>
       );
 
       expect(screen.getByTestId('child')).toHaveTextContent('Hello');
@@ -195,9 +196,9 @@ describe('WalletContext', () => {
 
     it('should provide default disconnected state', async () => {
       render(
-        <WalletProvider>
+        <NetworkProvider><WalletProvider>
           <TestConsumer />
-        </WalletProvider>
+        </WalletProvider></NetworkProvider>
       );
 
       await waitFor(() => {
@@ -209,9 +210,9 @@ describe('WalletContext', () => {
 
     it('should provide default network as mainnet', async () => {
       render(
-        <WalletProvider>
+        <NetworkProvider><WalletProvider>
           <TestConsumer />
-        </WalletProvider>
+        </WalletProvider></NetworkProvider>
       );
 
       await waitFor(() => {
@@ -221,9 +222,9 @@ describe('WalletContext', () => {
 
     it('should provide default token filter as tokens', async () => {
       render(
-        <WalletProvider>
+        <NetworkProvider><WalletProvider>
           <TestConsumer />
-        </WalletProvider>
+        </WalletProvider></NetworkProvider>
       );
 
       await waitFor(() => {
@@ -235,9 +236,9 @@ describe('WalletContext', () => {
       mockLoadAddressMode.mockReturnValue({ mode: 'change' });
 
       render(
-        <WalletProvider>
+        <NetworkProvider><WalletProvider>
           <TestConsumer />
-        </WalletProvider>
+        </WalletProvider></NetworkProvider>
       );
 
       await waitFor(() => {
@@ -262,9 +263,9 @@ describe('WalletContext', () => {
   describe('error management', () => {
     it('should allow setting error message', async () => {
       render(
-        <WalletProvider>
+        <NetworkProvider><WalletProvider>
           <TestConsumer />
-        </WalletProvider>
+        </WalletProvider></NetworkProvider>
       );
 
       await waitFor(() => {
@@ -280,9 +281,9 @@ describe('WalletContext', () => {
 
     it('should allow clearing error message', async () => {
       render(
-        <WalletProvider>
+        <NetworkProvider><WalletProvider>
           <TestConsumer />
-        </WalletProvider>
+        </WalletProvider></NetworkProvider>
       );
 
       await act(async () => {
@@ -303,9 +304,9 @@ describe('WalletContext', () => {
       mockUseMetaMaskContext.mockReturnValue({ error: metamaskError });
 
       render(
-        <WalletProvider>
+        <NetworkProvider><WalletProvider>
           <TestConsumer />
-        </WalletProvider>
+        </WalletProvider></NetworkProvider>
       );
 
       await waitFor(() => {
@@ -320,9 +321,9 @@ describe('WalletContext', () => {
       mockUseMetaMaskContext.mockReturnValue({ error: plainObjectError });
 
       render(
-        <WalletProvider>
+        <NetworkProvider><WalletProvider>
           <TestConsumer />
-        </WalletProvider>
+        </WalletProvider></NetworkProvider>
       );
 
       await waitFor(() => {
@@ -336,9 +337,9 @@ describe('WalletContext', () => {
   describe('token filter', () => {
     it('should allow changing token filter', async () => {
       render(
-        <WalletProvider>
+        <NetworkProvider><WalletProvider>
           <TestConsumer />
-        </WalletProvider>
+        </WalletProvider></NetworkProvider>
       );
 
       await waitFor(() => {
@@ -360,9 +361,9 @@ describe('WalletContext', () => {
       localStorage.setItem('hathor_wallet_network', 'testnet');
 
       render(
-        <WalletProvider>
+        <NetworkProvider><WalletProvider>
           <TestConsumer />
-        </WalletProvider>
+        </WalletProvider></NetworkProvider>
       );
 
       await act(async () => {
@@ -402,9 +403,9 @@ describe('WalletContext', () => {
       );
 
       render(
-        <WalletProvider>
+        <NetworkProvider><WalletProvider>
           <TestConsumer />
-        </WalletProvider>
+        </WalletProvider></NetworkProvider>
       );
 
       // Should attempt to initialize with stored xpub
@@ -415,9 +416,9 @@ describe('WalletContext', () => {
 
     it('should not check connection when no xpub stored', async () => {
       render(
-        <WalletProvider>
+        <NetworkProvider><WalletProvider>
           <TestConsumer />
-        </WalletProvider>
+        </WalletProvider></NetworkProvider>
       );
 
       await waitFor(() => {
@@ -434,9 +435,9 @@ describe('WalletContext', () => {
       let capturedContext: ReturnType<typeof useWallet> | null = null;
 
       render(
-        <WalletProvider>
+        <NetworkProvider><WalletProvider>
           <TestConsumer onContext={(ctx) => { capturedContext = ctx; }} />
-        </WalletProvider>
+        </WalletProvider></NetworkProvider>
       );
 
       await waitFor(() => {
@@ -465,9 +466,9 @@ describe('WalletContext', () => {
       let capturedContext: ReturnType<typeof useWallet> | null = null;
 
       render(
-        <WalletProvider>
+        <NetworkProvider><WalletProvider>
           <TestConsumer onContext={(ctx) => { capturedContext = ctx; }} />
-        </WalletProvider>
+        </WalletProvider></NetworkProvider>
       );
 
       await waitFor(() => {
@@ -501,9 +502,9 @@ describe('WalletContext', () => {
       }));
 
       render(
-        <WalletProvider>
+        <NetworkProvider><WalletProvider>
           <TestConsumer />
-        </WalletProvider>
+        </WalletProvider></NetworkProvider>
       );
 
       // Start connection
@@ -524,9 +525,9 @@ describe('WalletContext', () => {
       mockRequestSnap.mockRejectedValue(new Error('User rejected'));
 
       render(
-        <WalletProvider>
+        <NetworkProvider><WalletProvider>
           <TestConsumer />
-        </WalletProvider>
+        </WalletProvider></NetworkProvider>
       );
 
       await act(async () => {
@@ -568,9 +569,9 @@ describe('WalletContext', () => {
       );
 
       render(
-        <WalletProvider>
+        <NetworkProvider><WalletProvider>
           <TestConsumer />
-        </WalletProvider>
+        </WalletProvider></NetworkProvider>
       );
 
       await act(async () => {

--- a/packages/web-wallet/src/contexts/hooks/__tests__/useNetworkManagement.test.ts
+++ b/packages/web-wallet/src/contexts/hooks/__tests__/useNetworkManagement.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useNetworkManagement } from '../useNetworkManagement';
+import { NetworkProvider } from '../../NetworkContext';
 import { SnapUnauthorizedError } from '../../../services/SnapService';
 import type { AddressMode } from '../../../utils/addressMode';
 
@@ -112,8 +113,9 @@ describe('useNetworkManagement', () => {
 
   describe('changeNetwork', () => {
     it('should do nothing when not connected', async () => {
-      const { result } = renderHook(() =>
-        useNetworkManagement({ ...defaultOptions, isConnected: false })
+      const { result } = renderHook(
+        () => useNetworkManagement({ ...defaultOptions, isConnected: false }),
+        { wrapper: NetworkProvider }
       );
 
       await act(async () => {
@@ -124,8 +126,9 @@ describe('useNetworkManagement', () => {
     });
 
     it('should do nothing when xpub is null', async () => {
-      const { result } = renderHook(() =>
-        useNetworkManagement({ ...defaultOptions, xpub: null })
+      const { result } = renderHook(
+        () => useNetworkManagement({ ...defaultOptions, xpub: null }),
+        { wrapper: NetworkProvider }
       );
 
       await act(async () => {
@@ -136,7 +139,7 @@ describe('useNetworkManagement', () => {
     });
 
     it('should successfully change network', async () => {
-      const { result } = renderHook(() => useNetworkManagement(defaultOptions));
+      const { result } = renderHook(() => useNetworkManagement(defaultOptions), { wrapper: NetworkProvider });
 
       await act(async () => {
         await result.current.changeNetwork('testnet');
@@ -170,7 +173,7 @@ describe('useNetworkManagement', () => {
     });
 
     it('should show loading steps during network change', async () => {
-      const { result } = renderHook(() => useNetworkManagement(defaultOptions));
+      const { result } = renderHook(() => useNetworkManagement(defaultOptions), { wrapper: NetworkProvider });
 
       await act(async () => {
         await result.current.changeNetwork('testnet');
@@ -188,7 +191,7 @@ describe('useNetworkManagement', () => {
         new SnapUnauthorizedError('Permission denied', 4100)
       );
 
-      const { result } = renderHook(() => useNetworkManagement(defaultOptions));
+      const { result } = renderHook(() => useNetworkManagement(defaultOptions), { wrapper: NetworkProvider });
 
       await act(async () => {
         await result.current.changeNetwork('testnet');
@@ -201,7 +204,7 @@ describe('useNetworkManagement', () => {
     it('should force disconnect on snap crash without rollback', async () => {
       mockInvokeSnap.mockRejectedValue(new Error('DataCloneError: Failed to clone'));
 
-      const { result } = renderHook(() => useNetworkManagement(defaultOptions));
+      const { result } = renderHook(() => useNetworkManagement(defaultOptions), { wrapper: NetworkProvider });
 
       await act(async () => {
         await result.current.changeNetwork('testnet');
@@ -223,7 +226,7 @@ describe('useNetworkManagement', () => {
         // Second call (rollback) succeeds
         .mockResolvedValueOnce({ response: { success: true } });
 
-      const { result } = renderHook(() => useNetworkManagement(defaultOptions));
+      const { result } = renderHook(() => useNetworkManagement(defaultOptions), { wrapper: NetworkProvider });
 
       await act(async () => {
         await result.current.changeNetwork('testnet');
@@ -257,7 +260,7 @@ describe('useNetworkManagement', () => {
       // Rollback also fails (via raceWithTimeout)
       mockRaceWithTimeout.mockRejectedValueOnce(new Error('Rollback timeout'));
 
-      const { result } = renderHook(() => useNetworkManagement(defaultOptions));
+      const { result } = renderHook(() => useNetworkManagement(defaultOptions), { wrapper: NetworkProvider });
 
       await act(async () => {
         await result.current.changeNetwork('testnet');
@@ -275,7 +278,7 @@ describe('useNetworkManagement', () => {
     it('should handle address fetch failure during network change', async () => {
       mockGetAddressForMode.mockRejectedValue(new Error('Address derivation failed'));
 
-      const { result } = renderHook(() => useNetworkManagement(defaultOptions));
+      const { result } = renderHook(() => useNetworkManagement(defaultOptions), { wrapper: NetworkProvider });
 
       await act(async () => {
         await result.current.changeNetwork('testnet');
@@ -287,17 +290,22 @@ describe('useNetworkManagement', () => {
       );
     });
 
-    it('should save network to localStorage only after successful change', async () => {
+    it('should delegate network persistence via onNetworkChange after a successful change', async () => {
       const localStorageSpy = vi.spyOn(Storage.prototype, 'setItem');
 
-      const { result } = renderHook(() => useNetworkManagement(defaultOptions));
+      const { result } = renderHook(() => useNetworkManagement(defaultOptions), { wrapper: NetworkProvider });
 
       await act(async () => {
         await result.current.changeNetwork('testnet');
       });
 
-      // Should only save after state update
-      expect(localStorageSpy).toHaveBeenCalledWith('hathor_wallet_network', 'testnet');
+      // Persistence is centralized in the NetworkProvider. The hook no longer
+      // writes the network key directly; it delegates via onNetworkChange, which
+      // the app wires to setNetwork (the provider persists).
+      expect(mockOnNetworkChange).toHaveBeenCalledWith(
+        expect.objectContaining({ network: 'testnet' })
+      );
+      expect(localStorageSpy).not.toHaveBeenCalledWith('hathor_wallet_network', 'testnet');
 
       localStorageSpy.mockRestore();
     });
@@ -306,7 +314,7 @@ describe('useNetworkManagement', () => {
       const localStorageSpy = vi.spyOn(Storage.prototype, 'setItem');
       mockInvokeSnap.mockRejectedValue(new Error('Failed'));
 
-      const { result } = renderHook(() => useNetworkManagement(defaultOptions));
+      const { result } = renderHook(() => useNetworkManagement(defaultOptions), { wrapper: NetworkProvider });
 
       await act(async () => {
         await result.current.changeNetwork('testnet');
@@ -321,7 +329,7 @@ describe('useNetworkManagement', () => {
     it('should handle ERR_NETWORK as snap crash', async () => {
       mockInvokeSnap.mockRejectedValue(new Error('ERR_NETWORK: Connection reset'));
 
-      const { result } = renderHook(() => useNetworkManagement(defaultOptions));
+      const { result } = renderHook(() => useNetworkManagement(defaultOptions), { wrapper: NetworkProvider });
 
       await act(async () => {
         await result.current.changeNetwork('testnet');
@@ -334,7 +342,7 @@ describe('useNetworkManagement', () => {
     it('should handle Network Error as snap crash', async () => {
       mockInvokeSnap.mockRejectedValue(new Error('Network Error'));
 
-      const { result } = renderHook(() => useNetworkManagement(defaultOptions));
+      const { result } = renderHook(() => useNetworkManagement(defaultOptions), { wrapper: NetworkProvider });
 
       await act(async () => {
         await result.current.changeNetwork('testnet');
@@ -349,7 +357,7 @@ describe('useNetworkManagement', () => {
         address: 'HTestnetFirstAddr',
       });
 
-      const { result } = renderHook(() => useNetworkManagement(defaultOptions));
+      const { result } = renderHook(() => useNetworkManagement(defaultOptions), { wrapper: NetworkProvider });
 
       await act(async () => {
         await result.current.changeNetwork('testnet');
@@ -371,7 +379,7 @@ describe('useNetworkManagement', () => {
         new Error('Address lookup failed')
       );
 
-      const { result } = renderHook(() => useNetworkManagement(defaultOptions));
+      const { result } = renderHook(() => useNetworkManagement(defaultOptions), { wrapper: NetworkProvider });
 
       await act(async () => {
         await result.current.changeNetwork('testnet');
@@ -398,7 +406,7 @@ describe('useNetworkManagement', () => {
       // Rollback address fetch succeeds
       mockGetAddressForMode.mockResolvedValueOnce('HAddr123');
 
-      const { result } = renderHook(() => useNetworkManagement(defaultOptions));
+      const { result } = renderHook(() => useNetworkManagement(defaultOptions), { wrapper: NetworkProvider });
 
       await act(async () => {
         await result.current.changeNetwork('testnet');

--- a/packages/web-wallet/src/contexts/hooks/__tests__/useWalletConnection.test.ts
+++ b/packages/web-wallet/src/contexts/hooks/__tests__/useWalletConnection.test.ts
@@ -86,6 +86,7 @@ vi.mock('@hathor/snap-utils', () => ({
 
 vi.mock('../../../constants', () => ({
   DEFAULT_NETWORK: 'mainnet',
+  NETWORK_STORAGE_KEY: 'hathor_wallet_network',
   TOKEN_IDS: { HTR: '00' },
   CHECK_CONNECTION_TIMEOUT: 30000,
 }));
@@ -99,6 +100,7 @@ vi.mock('../../../constants/timeouts', () => ({
 }));
 
 import { useWalletConnection } from '../useWalletConnection';
+import { NetworkProvider } from '../../NetworkContext';
 import type { AddressMode } from '../../../utils/addressMode';
 
 describe('useWalletConnection - checkExistingConnection network verification', () => {
@@ -180,7 +182,7 @@ describe('useWalletConnection - checkExistingConnection network verification', (
     });
 
     await act(async () => {
-      renderHook(() => useWalletConnection(defaultOptions));
+      renderHook(() => useWalletConnection(defaultOptions), { wrapper: NetworkProvider });
     });
 
     await vi.waitFor(() => {
@@ -207,7 +209,7 @@ describe('useWalletConnection - checkExistingConnection network verification', (
     });
 
     await act(async () => {
-      renderHook(() => useWalletConnection(defaultOptions));
+      renderHook(() => useWalletConnection(defaultOptions), { wrapper: NetworkProvider });
     });
 
     await vi.waitFor(() => {
@@ -236,7 +238,7 @@ describe('useWalletConnection - checkExistingConnection network verification', (
     mockInvokeSnap.mockRejectedValueOnce(new Error('Failed to change network'));
 
     await act(async () => {
-      renderHook(() => useWalletConnection(defaultOptions));
+      renderHook(() => useWalletConnection(defaultOptions), { wrapper: NetworkProvider });
     });
 
     await vi.waitFor(() => {
@@ -258,7 +260,7 @@ describe('useWalletConnection - checkExistingConnection network verification', (
     mockInvokeSnap.mockRejectedValueOnce(new Error('Snap not responding'));
 
     await act(async () => {
-      renderHook(() => useWalletConnection(defaultOptions));
+      renderHook(() => useWalletConnection(defaultOptions), { wrapper: NetworkProvider });
     });
 
     await vi.waitFor(() => {
@@ -281,7 +283,7 @@ describe('useWalletConnection - checkExistingConnection network verification', (
     mockInvokeSnap.mockResolvedValueOnce({ response: { success: true } });
 
     await act(async () => {
-      renderHook(() => useWalletConnection(defaultOptions));
+      renderHook(() => useWalletConnection(defaultOptions), { wrapper: NetworkProvider });
     });
 
     await vi.waitFor(() => {

--- a/packages/web-wallet/src/contexts/hooks/useNetworkManagement.ts
+++ b/packages/web-wallet/src/contexts/hooks/useNetworkManagement.ts
@@ -1,4 +1,5 @@
 import { readOnlyWalletWrapper } from '../../services/ReadOnlyWalletWrapper';
+import { useNetwork } from '../NetworkContext';
 import { SnapUnauthorizedError } from '../../services/SnapService';
 import { getAddressForMode, type AddressMode } from '../../utils/addressMode';
 import { TOKEN_IDS } from '@/constants';
@@ -12,7 +13,6 @@ const log = createLogger('useNetworkManagement');
 
 const STORAGE_KEYS = {
   XPUB: 'hathor_wallet_xpub',
-  NETWORK: 'hathor_wallet_network',
 };
 
 interface UseNetworkManagementOptions {
@@ -63,6 +63,10 @@ export function useNetworkManagement(options: UseNetworkManagementOptions) {
     stopWallet,
     reinitializeWallet,
   } = options;
+
+  // Network persistence is centralized in the NetworkProvider. Successful changes
+  // persist via onNetworkChange -> connection.setNetwork; failures clear it here.
+  const { clearNetwork } = useNetwork();
 
   const changeNetwork = async (newNetwork: string) => {
     if (!isConnected || !xpub) {
@@ -123,16 +127,14 @@ export function useNetworkManagement(options: UseNetworkManagementOptions) {
 
       const newBalances = await readOnlyWalletWrapper.getBalance(TOKEN_IDS.HTR);
 
-      // Update app state first (can throw)
+      // Update app state first (can throw). onNetworkChange routes to
+      // connection.setNetwork, which persists the new network via the provider.
       onNetworkChange({
         network: newNetwork,
         address: newAddress,
         firstAddress: newFirstAddress,
         balances: newBalances,
       });
-
-      // Only persist to localStorage after state update succeeds
-      localStorage.setItem(STORAGE_KEYS.NETWORK, newNetwork);
 
       // Load tokens for the new network (managed by useTokenState)
       await onLoadTokens(newNetwork);
@@ -160,7 +162,7 @@ export function useNetworkManagement(options: UseNetworkManagementOptions) {
 
         // Don't attempt rollback if snap crashed - just disconnect
         localStorage.removeItem(STORAGE_KEYS.XPUB);
-        localStorage.removeItem(STORAGE_KEYS.NETWORK);
+        clearNetwork();
 
         try {
           await stopWallet();
@@ -219,7 +221,7 @@ export function useNetworkManagement(options: UseNetworkManagementOptions) {
 
         // Clear localStorage and stop wallet
         localStorage.removeItem(STORAGE_KEYS.XPUB);
-        localStorage.removeItem(STORAGE_KEYS.NETWORK);
+        clearNetwork();
 
         try {
           await stopWallet();

--- a/packages/web-wallet/src/contexts/hooks/useWalletConnection.ts
+++ b/packages/web-wallet/src/contexts/hooks/useWalletConnection.ts
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { readOnlyWalletWrapper } from '../../services/ReadOnlyWalletWrapper';
 import { SnapUnauthorizedError } from '../../services/SnapService';
-import { CHECK_CONNECTION_TIMEOUT, DEFAULT_NETWORK, TOKEN_IDS } from '@/constants';
+import { CHECK_CONNECTION_TIMEOUT, TOKEN_IDS } from '@/constants';
+import { useNetwork } from '../NetworkContext';
 import { getAddressForMode, type AddressMode } from '../../utils/addressMode';
 import { SNAP_TIMEOUTS } from '../../constants/timeouts';
 import { createLogger } from '../../utils/logger';
@@ -62,7 +63,6 @@ const GetSnapsResponseSchema = z.record(
 
 const STORAGE_KEYS = {
   XPUB: 'hathor_wallet_xpub',
-  NETWORK: 'hathor_wallet_network',
 };
 
 interface UseWalletConnectionOptions {
@@ -169,7 +169,10 @@ export function useWalletConnection(options: UseWalletConnectionOptions): Wallet
   const [xpub, setXpub] = useState<string | null>(null);
   const [address, setAddress] = useState('');
   const [balances, setBalances] = useState<Map<string, WalletBalance>>(new Map());
-  const [network, setNetwork] = useState('mainnet');
+  // Network is owned by the NetworkProvider (single source of truth, shared with
+  // the FeatureToggleProvider). This hook reads it and drives changes through the
+  // provider, which also centralizes localStorage persistence.
+  const { network, setNetwork, clearNetwork } = useNetwork();
   const [snapVersion, setSnapVersion] = useState<string | null>(null);
   const [firstAddress, setFirstAddress] = useState<string | null>(null);
   // NOTE: Token state moved to useTokenState - this hook no longer manages tokens
@@ -339,7 +342,8 @@ export function useWalletConnection(options: UseWalletConnectionOptions): Wallet
 
     try {
       const storedXpub = localStorage.getItem(STORAGE_KEYS.XPUB);
-      const storedNetwork = localStorage.getItem(STORAGE_KEYS.NETWORK) || DEFAULT_NETWORK;
+      // The provider seeds from localStorage, so this reflects the persisted network.
+      const storedNetwork = network;
 
       if (!storedXpub) {
         setIsCheckingConnection(false);
@@ -402,8 +406,8 @@ export function useWalletConnection(options: UseWalletConnectionOptions): Wallet
             } catch (networkChangeError) {
               // If we can't change snap to stored network, use the snap's current network instead
               log.error('Failed to change snap network, using snap network:', networkChangeError);
+              // Persisted below via setNetwork once the wallet state is updated.
               verifiedNetwork = currentSnapNetwork;
-              localStorage.setItem(STORAGE_KEYS.NETWORK, verifiedNetwork);
             }
           }
         }
@@ -474,7 +478,7 @@ export function useWalletConnection(options: UseWalletConnectionOptions): Wallet
 
       if (shouldClearStorage) {
         localStorage.removeItem(STORAGE_KEYS.XPUB);
-        localStorage.removeItem(STORAGE_KEYS.NETWORK);
+        clearNetwork();
       }
 
       // Generate user-friendly message
@@ -547,10 +551,10 @@ export function useWalletConnection(options: UseWalletConnectionOptions): Wallet
         throw new Error('Snap is not responding. Please make sure it is installed correctly.');
       }
 
-      // Use the snap's current network. If it's a first-time connection (no stored network),
-      // default to DEFAULT_NETWORK. This avoids forcing users back to mainnet on every reconnect.
-      const storedNetwork = localStorage.getItem(STORAGE_KEYS.NETWORK);
-      const targetNetwork = storedNetwork || DEFAULT_NETWORK;
+      // Use the last persisted network (from the provider). On a first-time
+      // connection this defaults to DEFAULT_NETWORK, avoiding forcing users back
+      // to mainnet on every reconnect.
+      const targetNetwork = network;
 
       if (currentSnapNetwork !== targetNetwork) {
         setLoadingStep(`Changing snap network to ${targetNetwork}...`);
@@ -614,7 +618,7 @@ export function useWalletConnection(options: UseWalletConnectionOptions): Wallet
       const walletState = await loadWalletState(addressMode);
 
       localStorage.setItem(STORAGE_KEYS.XPUB, newXpub);
-      localStorage.setItem(STORAGE_KEYS.NETWORK, newNetwork);
+      // Network is persisted by the provider via setNetwork below.
 
       setIsConnected(true);
       setAddress(walletState.address);
@@ -636,7 +640,7 @@ export function useWalletConnection(options: UseWalletConnectionOptions): Wallet
       if (hasErrorCode(error, PROVIDER_ERROR_CODES.UNAUTHORIZED)) {
         log.error('Snap unauthorized - showing connection lost modal');
         localStorage.removeItem(STORAGE_KEYS.XPUB);
-        localStorage.removeItem(STORAGE_KEYS.NETWORK);
+        clearNetwork();
         onShowConnectionLostModal(true);
         setIsConnecting(false);
         setLoadingStep('');
@@ -679,7 +683,7 @@ export function useWalletConnection(options: UseWalletConnectionOptions): Wallet
     setAddress('');
     setFirstAddress(null);
     setBalances(new Map());
-    setNetwork('mainnet');
+    clearNetwork();
     setXpub(null);
     setSnapVersion(null);
     // NOTE: Token clearing is handled by useTokenState via isConnected change


### PR DESCRIPTION
### Motivation

The web-wallet should let users create fee-based tokens, but only on **testnet** and behind a feature flag, so the feature can be rolled out gradually. The`fee-based-tokens-webwallet.rollout` Unleash flag is constrained to `network = testnet`, but the web-wallet never told Unleash which network it was on — so the flag never resolved and the feature stayed hidden on every environment. This PR sends the active network to Unleash and gates the fee-based token UI and flow behind the per-network flag.

> Stacked on top of #166 (`raul-oliveira/feat/fee-based-tokens-activation`) — review/merge that one first.

### Acceptance Criteria

- Fee-based token creation is available only when the wallet is connected the `fee-based-tokens-webwallet.rollout` flag is enabled.
- The web-wallet reports its active network to Unleash, so the flag's `network = testnet` constraint is actually evaluated (previously it never matched on any environment).
- On testnet with the flag enabled, the Create Token dialog shows the **Token Type (Deposit / Fee)** selector and lets the user create a fee-based token — no HTR deposit required, sending `version: 'fee'` in the create-token request.
- On **mainnet**, or whenever the flag is disabled, the Token Type selector is hidden and token creation behaves exactly as before the feature (deposit tokens only).
- Switching the network at runtime enables or disables the feature immediately, without reloading the page.
- The web-wallet flag is independent from hathor-wallet-mobile's `fee-based-tokens.rollout`, so each client can be rolled out separately.

### Checklist
- [ ] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged _(N/A — targets the stacked feature branch, not `master`)_
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced fee-based tokens feature toggle (currently disabled by default).
  * Added centralized network management for Hathor network selection with persistent storage.

* **Chores**
  * Updated token creation dialog to conditionally display based on feature toggle status.
  * Refactored provider hierarchy to integrate network context throughout the application.
  * Updated test suite to reflect new provider structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->