### PR TITLE
fix(web-wallet): show real snap error message instead of [object Object]

### DIFF
--- a/packages/web-wallet/src/contexts/hooks/__tests__/useNetworkManagement.test.ts
+++ b/packages/web-wallet/src/contexts/hooks/__tests__/useNetworkManagement.test.ts
@@ -55,6 +55,8 @@ vi.mock('../../../utils/snapErrors', () => ({
     msg.includes('postMessage') ||
     msg.includes('cloned') ||
     msg.includes('timeout'),
+  extractErrorMessage: (err: unknown, fallback: string) =>
+    err instanceof Error ? err.message : fallback,
 }));
 
 describe('useNetworkManagement', () => {

--- a/packages/web-wallet/src/contexts/hooks/useNetworkManagement.ts
+++ b/packages/web-wallet/src/contexts/hooks/useNetworkManagement.ts
@@ -6,7 +6,7 @@ import { TOKEN_IDS } from '@/constants';
 import { SNAP_TIMEOUTS } from '../../constants/timeouts';
 import { createLogger } from '../../utils/logger';
 import { raceWithTimeout } from '../../utils/promise';
-import { isSnapCrashedError } from '../../utils/snapErrors';
+import { isSnapCrashedError, extractErrorMessage } from '../../utils/snapErrors';
 import type { WalletBalance } from '../../types/wallet';
 
 const log = createLogger('useNetworkManagement');
@@ -149,7 +149,7 @@ export function useNetworkManagement(options: UseNetworkManagementOptions) {
         return;
       }
 
-      const originalError = networkChangeError instanceof Error ? networkChangeError.message : String(networkChangeError);
+      const originalError = extractErrorMessage(networkChangeError, 'Unknown error');
       log.error('Failed to change network:', networkChangeError);
 
       // Check if snap crashed (DataCloneError, unresponsive, etc.)

--- a/packages/web-wallet/src/contexts/hooks/useWalletConnection.ts
+++ b/packages/web-wallet/src/contexts/hooks/useWalletConnection.ts
@@ -292,7 +292,7 @@ export function useWalletConnection(options: UseWalletConnectionOptions): Wallet
     try {
       walletAddress = await getAddressForMode(addressMode, readOnlyWalletWrapper);
     } catch (addressError) {
-      const originalMessage = addressError instanceof Error ? addressError.message : String(addressError);
+      const originalMessage = extractErrorMessage(addressError, 'Unknown error');
       log.error('Failed to get display address:', originalMessage);
       throw new Error(`Failed to retrieve wallet address: ${originalMessage}`);
     }
@@ -306,7 +306,7 @@ export function useWalletConnection(options: UseWalletConnectionOptions): Wallet
       }
       walletFirstAddress = addressInfo.address;
     } catch (addressError) {
-      const originalMessage = addressError instanceof Error ? addressError.message : String(addressError);
+      const originalMessage = extractErrorMessage(addressError, 'Unknown error');
       log.error('Failed to get first address:', originalMessage);
       throw new Error(`Failed to retrieve first address: ${originalMessage}`);
     }
@@ -444,7 +444,7 @@ export function useWalletConnection(options: UseWalletConnectionOptions): Wallet
         await onConnectionReady(verifiedNetwork);
       }
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = extractErrorMessage(error, 'Unknown error');
 
       // Ignore concurrent initialization (React Strict Mode double-mount)
       if (errorMessage.includes(ERROR_PATTERNS.ALREADY_INITIALIZING)) {
@@ -594,7 +594,7 @@ export function useWalletConnection(options: UseWalletConnectionOptions): Wallet
           'Get xpub timeout'
         );
       } catch (snapError) {
-        throw new Error(`Failed to get xpub: ${snapError instanceof Error ? snapError.message : String(snapError)}`);
+        throw new Error(`Failed to get xpub: ${extractErrorMessage(snapError, 'Unknown error')}`);
       }
 
       // Parse and validate xpub response
@@ -634,7 +634,7 @@ export function useWalletConnection(options: UseWalletConnectionOptions): Wallet
         await onConnectionReady(newNetwork);
       }
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = extractErrorMessage(error, 'Failed to connect to wallet');
 
       // Check for unauthorized (code 4100)
       if (hasErrorCode(error, PROVIDER_ERROR_CODES.UNAUTHORIZED)) {
@@ -776,7 +776,7 @@ export function useWalletConnection(options: UseWalletConnectionOptions): Wallet
     checkExistingConnection(abortController.signal)
       .catch((error) => {
         // Ignore aborted errors
-        const errorMessage = error instanceof Error ? error.message : String(error);
+        const errorMessage = extractErrorMessage(error, 'Unknown error');
         if (errorMessage.includes('aborted')) {
           return;
         }


### PR DESCRIPTION
### Motivation

The web-wallet connect screen showed `Failed to get xpub: [object Object]`. Snap/MetaMask RPC errors are re-thrown as plain JSON-RPC objects (`{ code, message }`), not `Error` instances, so the `error instanceof Error ? error.message : String(error)` pattern fell back to `String(error)` → `[object Object]`. The same pattern was repeated across 7 call sites.

### Acceptance Criteria

- Snap errors render the real message instead of `[object Object]` (e.g. on the connect screen)
- New `getErrorMessage()` helper extracts the message from `Error` instances, JSON-RPC error objects and strings, and never returns `[object Object]`
- All 7 occurrences of the old pattern route through the helper
- Original error object is preserved, so `code`-based checks (e.g. `isUnauthorizedError`) keep working

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized error message extraction across wallet connection and network management operations to improve consistency in error handling.

* **Tests**
  * Updated test infrastructure for standardized error message extraction support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->