### PR TITLE
chore: bump rpc-handler to v5.0.0 and snap to v0.5.0

### DIFF
--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -11,7 +11,7 @@
       "name": "MIT",
       "url": "https://github.com/HathorNetwork/hathor-rpc-lib/blob/release/LICENSE"
     },
-    "version": "0.3.0-experimental-alpha"
+    "version": "0.4.0-experimental-alpha"
   },
   "methods": [
     {

--- a/packages/hathor-rpc-handler/package.json
+++ b/packages/hathor-rpc-handler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hathor/hathor-rpc-handler",
   "license": "MIT",
-  "version": "4.4.0",
+  "version": "5.0.0",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [

--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hathor/snap",
   "packageManager": "yarn@4.2.2",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "",
   "license": "",
   "main": "./dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Hathor Network Snap integration",
   "proposedName": "Hathor Wallet",
   "source": {


### PR DESCRIPTION
### Acceptance Criteria
- Bump `@hathor/hathor-rpc-handler` to v5.0.0
- Bump `@hathor/snap` to v0.5.0

> [!IMPORTANT]
> **Draft until #172 (and the consumer PRs) merge.** These bumps only make sense once the breaking changes from #172 land on `master`. Merge order: **#172 first, then this PR**, which finalizes the versions that trigger the releases. Following the repo convention, version bumps land in a dedicated PR separate from the feature — this PR carries **both** the `hathor-rpc-handler` and `snap` bumps for #172 (per the review on #172, the snap bump was reverted there and reused here).

### Breaking Changes

From **#172 — feat!: prompt-free getBalance for connected dApps with all wallet tokens**:

#### `@hathor/hathor-rpc-handler` (4.x → 5.0.0)

- **Removed exported types** `GetBalanceConfirmationPrompt` and `GetBalanceConfirmationResponse`, along with their members in the `TriggerTypes` / `TriggerResponseTypes` enums and the `Trigger` / `TriggerResponse` unions. Any consumer importing these will fail to compile.

  _Migration:_ delete those imports and remove the `case TriggerTypes.GetBalanceConfirmationPrompt` branch from your prompt handler — `htr_getBalance` no longer emits a prompt. Note that the numeric `TriggerTypes` / `TriggerResponseTypes` enum values shift as a side effect of the removed members; do not persist or transmit these raw numeric values across versions.

- **`htr_getBalance` no longer prompts for confirmation.** It returns `GetBalanceObject[]` immediately (response `type` `3`), mirroring the prompt-free `getConnectedNetwork` / `getWalletInformation` handlers. Consumers relying on the per-request prompt (mobile, desktop) must drop their balance modals — handled in separate PRs.

- **`tokens` is now optional.** Omit it to get the balance of all the wallet's tokens; provide a list to get just that subset. Previously `tokens` was required.

#### `@hathor/snap` (0.4.2 → 0.5.0)

- **Removed the per-request balance confirmation dialog.** `htr_getBalance` is now frictionless, in line with the prompt-free handler above; the `dialogs/balance.tsx` surface and its prompt-handler branch were deleted.
- **Install dialog disclosure reworded** to cover the balance of all the wallet's tokens (dropping the client-specific "registered tokens" wording).

### What's included

| PR | Type | Title |
|---|---|---|
| #172 | feat | prompt-free getBalance for connected dApps with all wallet tokens |

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package and manifest version numbers for the latest release.
  * Bumped one component from `4.4.0` to `5.0.0`.
  * Bumped another component and its manifest from `0.4.2` to `0.5.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->