### PR TITLE
fix(web-wallet): replace setimmediate polyfill with MessageChannel shim

### DIFF
--- a/packages/web-wallet/src/__tests__/setImmediate.shim.test.ts
+++ b/packages/web-wallet/src/__tests__/setImmediate.shim.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { setImmediate as setImmediateShim, clearImmediate as clearImmediateShim } from '../setImmediate.shim';
+
+describe('setImmediate shim', () => {
+  it('installs setImmediate and clearImmediate on the global object', () => {
+    expect(typeof (globalThis as { setImmediate?: unknown }).setImmediate).toBe('function');
+    expect(typeof (globalThis as { clearImmediate?: unknown }).clearImmediate).toBe('function');
+  });
+
+  it('invokes the callback asynchronously, never synchronously', async () => {
+    let called = false;
+    setImmediateShim(() => {
+      called = true;
+    });
+    expect(called).toBe(false);
+    await vi.waitFor(() => expect(called).toBe(true));
+  });
+
+  it('passes trailing arguments through to the callback', async () => {
+    const args = await new Promise<number[]>((resolve) => {
+      setImmediateShim((a: number, b: number) => resolve([a, b]), 1, 2);
+    });
+    expect(args).toEqual([1, 2]);
+  });
+
+  it('runs scheduled callbacks in FIFO order', async () => {
+    const order: number[] = [];
+    await new Promise<void>((resolve) => {
+      setImmediateShim(() => order.push(1));
+      setImmediateShim(() => order.push(2));
+      setImmediateShim(() => {
+        order.push(3);
+        resolve();
+      });
+    });
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it('clearImmediate cancels a callback that has not run yet', async () => {
+    let called = false;
+    const handle = setImmediateShim(() => {
+      called = true;
+    });
+    clearImmediateShim(handle);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(called).toBe(false);
+  });
+});

--- a/packages/web-wallet/src/main.tsx
+++ b/packages/web-wallet/src/main.tsx
@@ -1,3 +1,4 @@
+import './setImmediate.shim' // Must run before react-dom so React's scheduler uses the safe setImmediate
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './polyfills' // Must be imported first to set up global polyfills

--- a/packages/web-wallet/src/setImmediate.shim.ts
+++ b/packages/web-wallet/src/setImmediate.shim.ts
@@ -1,0 +1,85 @@
+/**
+ * MessageChannel-based replacement for the `setimmediate` package.
+ *
+ * The upstream `setimmediate` browser implementation schedules work through
+ * `window.postMessage` and only runs the callback when it receives a message
+ * whose `event.source === window`. Some wallet extensions proxy `event.source`,
+ * so that check never matches and every `setImmediate` consumer silently stops
+ * working — including React's scheduler, which prefers `setImmediate` over
+ * `MessageChannel` whenever a global `setImmediate` exists. The result is a
+ * blank screen with no error.
+ *
+ * A `MessageChannel` uses point-to-point ports with no `event.source` check, so
+ * it is immune to that interference. This module is aliased over `setimmediate`
+ * in webpack so the Node timer polyfills (timers-browserify, pulled in by
+ * `@hathor/wallet-lib`) and React's scheduler both get a working `setImmediate`.
+ */
+
+type ImmediateCallback = (...args: unknown[]) => void;
+
+interface ImmediateTask {
+  callback: ImmediateCallback;
+  args: unknown[];
+}
+
+const tasksByHandle = new Map<number, ImmediateTask>();
+let nextHandle = 1;
+let runningHandle: number | undefined;
+
+function runIfPresent(handle: number): void {
+  if (runningHandle !== undefined) {
+    // A task is already running: defer to keep execution non-reentrant.
+    setTimeout(runIfPresent, 0, handle);
+    return;
+  }
+  const task = tasksByHandle.get(handle);
+  if (!task) {
+    return;
+  }
+  runningHandle = handle;
+  try {
+    task.callback(...task.args);
+  } finally {
+    runningHandle = undefined;
+    tasksByHandle.delete(handle);
+  }
+}
+
+const schedule: (handle: number) => void = (() => {
+  if (typeof MessageChannel !== 'undefined') {
+    const channel = new MessageChannel();
+    channel.port1.onmessage = (event: MessageEvent) => {
+      runIfPresent(event.data as number);
+    };
+    return (handle: number) => {
+      channel.port2.postMessage(handle);
+    };
+  }
+  return (handle: number) => {
+    setTimeout(runIfPresent, 0, handle);
+  };
+})();
+
+export function setImmediate(callback: ImmediateCallback, ...args: unknown[]): number {
+  const handle = nextHandle;
+  nextHandle += 1;
+  tasksByHandle.set(handle, { callback, args });
+  schedule(handle);
+  return handle;
+}
+
+export function clearImmediate(handle: number): void {
+  tasksByHandle.delete(handle);
+}
+
+// Install on the global as a side effect (mirroring the `setimmediate` package)
+// so timers-browserify and React's scheduler pick up this implementation. The
+// overwrite is unconditional, and this module is imported before `react-dom` in
+// main.tsx, so it replaces any extension-injected polyfill before the scheduler
+// reads `setImmediate`.
+const globalScope = globalThis as unknown as {
+  setImmediate?: unknown;
+  clearImmediate?: unknown;
+};
+globalScope.setImmediate = setImmediate;
+globalScope.clearImmediate = clearImmediate;

--- a/packages/web-wallet/webpack.config.cjs
+++ b/packages/web-wallet/webpack.config.cjs
@@ -43,6 +43,12 @@ module.exports = (env, argv) => {
       alias: {
         '@': path.resolve(__dirname, './src'),
         '@hathor/snap-utils': path.resolve(__dirname, '../snap-utils/src'),
+        // Replace the `setimmediate` polyfill (pulled in transitively via the Node
+        // timer polyfills) with a MessageChannel-based implementation that is immune
+        // to wallet extensions proxying `event.source`. Without this, React's
+        // scheduler prefers the broken global `setImmediate` and never flushes,
+        // leaving a blank screen. See src/setImmediate.shim.ts.
+        'setimmediate': path.resolve(__dirname, 'src/setImmediate.shim.ts'),
         'buffer': require.resolve('buffer/'),
         'assert': stdLibBrowser.assert,
         'crypto': stdLibBrowser.crypto,


### PR DESCRIPTION
### Motivation

Users with certain wallet extensions installed (e.g. **Temple Wallet**, alongside MetaMask) saw a **fully blank screen with no console error** when opening the web wallet. The app was unusable and there was no way for the user to diagnose it.

Root cause (diagnosed and reproduced in a production build):

- React's scheduler prefers a global `setImmediate` over `MessageChannel` when one exists.
- The `setimmediate` polyfill is pulled into the bundle transitively via the Node `timers` polyfill (`timers-browserify`), which `@hathor/wallet-lib` requires. It schedules work through `window.postMessage` and only runs its callback when `event.source === window`.
- Wallet extensions such as Temple proxy `event.source`, so that check never matches → the scheduled callback never fires → React's initial render never commits → silent blank screen (nothing is thrown).

The fix replaces the fragile `setimmediate` polyfill with a `MessageChannel`-based implementation (point-to-point ports, no `event.source` check), imported before `react-dom` so React's scheduler picks it up before it initializes. This is the scheduling path React already uses natively in browsers, so the fix is **generic** — not specific to Temple; any extension/script that proxies `event.source` is covered.

For reference, `hathor-explorer` (same React + `@hathor/wallet-lib`) is unaffected because its webpack config omits the `timers` polyfill, so the `setimmediate` global is never installed there.

### Acceptance Criteria

- The web wallet renders for users who have a wallet extension that proxies `event.source` (e.g. Temple Wallet) installed.
- No regression for users without such extensions.
- `setImmediate` remains available and working for other consumers (e.g. `timers-browserify` used by `@hathor/wallet-lib`) — no capability removed.

**Verification**
- Reproduced in a local production build (LavaMoat lockdown) with the extension installed: **before** → `#root` empty, scheduler stuck (`pendingLanes` never flush), blank screen; **after** → wallet renders the connect screen.
- No regression in a profile without the extension (renders and connects).
- Unit tests covering the shim: `packages/web-wallet/src/__tests__/setImmediate.shim.test.ts`.

### Checklist
- [x] If you are requesting a merge into `master`, confirm this code is production-ready and can be included in future releases as soon as it gets merged
- [x] Make sure either the unit tests and/or the QA tests are capable of testing the new features
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local `setImmediate`/`clearImmediate` shim for the web wallet, installing them globally for consistent scheduling.
  * Ensured the shim loads before rendering so task timing remains stable.

* **Bug Fixes**
  * Improved immediate callback timing to run asynchronously and in FIFO order.
  * Added reliable cancellation support so cleared tasks don’t execute.

* **Tests**
  * Added coverage validating installation, argument forwarding, execution order, async behavior, and cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->